### PR TITLE
feat: Working tools server with execution / calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+*.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -1,10 +1,38 @@
-A WinterTC compliant TypeScript SDK for MCP
+<h1>
+  `@zuplo/mcp`
+</h1>
+  <p align="center">
+    A WinterTC compliant, remote server first, TypeScript SDK for MCP.
+    <br />
+    <a href="#about">About</a>
+    ·
+    <a href="#documentation">Documentation</a>
+    ·
+    <a href="#contributing">Contributing</a>
+  </p>
+</p>
 
 ---
 
-# Attributions
+**Attributions**
 
 Inspired by and attributed to [`modelcontextprotocol/typescript-sdk`](https://github.com/modelcontextprotocol/typescript-sdk), MIT licensed.
+
+# About
+
+`@zuplo/mcp` is a remote server first MCP SDK that aims to be WinterTC compliant.
+It uses the `fetch` APIs and aims to work out of the box on Zuplo, Node, Deno, Workerd, etc.
+
+TODO
+
+# Documentation
+
+TODO
+
+# Contributing
+
+TODO
+
 
 ---
 

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -13,6 +13,24 @@
       "**/package-lock.json"
     ]
   },
+  "linter": {
+    "enabled": true,
+
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUndeclaredVariables": "warn",
+        "useExhaustiveDependencies": "warn",
+        "useImportExtensions": "error"
+      },
+      "suspicious": {
+        "noExplicitAny": "error"
+      },
+      "style": {
+        "noDefaultExport": "off"
+      }
+    }
+  },
   "formatter": {
     "enabled": true,
     "useEditorconfig": true,

--- a/examples/ping-server/package-lock.json
+++ b/examples/ping-server/package-lock.json
@@ -1,0 +1,52 @@
+{
+  "name": "@zuplo/mcp ping example",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zuplo/mcp ping example",
+      "dependencies": {
+        "@zuplo/mcp": "file:../../"
+      }
+    },
+    "..": {
+      "name": "@zuplo/mcp",
+      "version": "0.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.24.4",
+        "zod-to-json-schema": "^3.24.5"
+      },
+      "devDependencies": {
+        "@types/jest": "^29.5.14",
+        "@types/node": "^22.15.14",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.3.2",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.3"
+      }
+    },
+    "../..": {
+      "name": "@zuplo/mcp",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.24.4",
+        "zod-to-json-schema": "^3.24.5"
+      },
+      "devDependencies": {
+        "@types/jest": "^29.5.14",
+        "@types/node": "^22.15.14",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.3.2",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@zuplo/mcp": {
+      "resolved": "../..",
+      "link": true
+    }
+  }
+}

--- a/examples/ping-server/package.json
+++ b/examples/ping-server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@zuplo/mcp ping example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@zuplo/mcp": "file:../../"
+  }
+}

--- a/examples/ping-server/src/index.ts
+++ b/examples/ping-server/src/index.ts
@@ -1,0 +1,25 @@
+import { JSONRPCRequest } from "@zuplo/mcp/jsonrpc2/types";
+import { MCPServer } from "@zuplo/mcp/server";
+
+// Create a simple server
+const server = new MCPServer({
+  name: "Example Ping Server",
+  version: "1.0.0",
+});
+
+console.log("Server capabilities:", server.getCapabilities());
+
+// Example ping request
+const pingRequest: JSONRPCRequest = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "ping",
+};
+
+async function runExample() {
+  console.log("Sending ping request:", pingRequest);
+  const response = await server.handleRequest(pingRequest);
+  console.log("Received response:", response);
+}
+
+runExample().catch(console.error);

--- a/examples/ping-server/tsconfig.json
+++ b/examples/ping-server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "./src/**/*"
+  ],
+  "references": [
+    { "path": "../../" }
+  ]
+}

--- a/examples/tools-server/package-lock.json
+++ b/examples/tools-server/package-lock.json
@@ -1,0 +1,52 @@
+{
+  "name": "@zuplo/mcp ping example",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zuplo/mcp ping example",
+      "dependencies": {
+        "@zuplo/mcp": "file:../../"
+      }
+    },
+    "..": {
+      "name": "@zuplo/mcp",
+      "version": "0.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.24.4",
+        "zod-to-json-schema": "^3.24.5"
+      },
+      "devDependencies": {
+        "@types/jest": "^29.5.14",
+        "@types/node": "^22.15.14",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.3.2",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.3"
+      }
+    },
+    "../..": {
+      "name": "@zuplo/mcp",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.24.4",
+        "zod-to-json-schema": "^3.24.5"
+      },
+      "devDependencies": {
+        "@types/jest": "^29.5.14",
+        "@types/node": "^22.15.14",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.3.2",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@zuplo/mcp": {
+      "resolved": "../..",
+      "link": true
+    }
+  }
+}

--- a/examples/tools-server/package.json
+++ b/examples/tools-server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@zuplo/mcp ping example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@zuplo/mcp": "file:../../"
+  }
+}

--- a/examples/tools-server/src/index.ts
+++ b/examples/tools-server/src/index.ts
@@ -1,0 +1,44 @@
+import { JSONRPCRequest } from "@zuplo/mcp/jsonrpc2/types";
+import { isJSONRPCResponse } from "@zuplo/mcp/jsonrpc2/validation";
+import { MCPServer } from "@zuplo/mcp/server";
+import { z } from "zod";
+
+// Create a simple server
+const server = new MCPServer({
+  name: "Example Ping Server",
+  version: "1.0.0",
+});
+
+server.addTool(
+  "add",
+  z.object({ a: z.number(), b: z.number() }),
+  async ({ a, b }) => (
+    [{ type: "text", text: String(a + b) }]
+  )
+);
+
+// Example ping request
+const toolRequest: JSONRPCRequest = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "tools/call",
+  params: {
+    name: "add",
+    arguments: {
+      a: 1,
+      b: 2,
+    },
+  },
+};
+
+async function runExample() {
+  console.log("Sending tool/call request:", toolRequest);
+  const response = await server.handleRequest(toolRequest);
+  if (isJSONRPCResponse(response)) {
+    console.log("Received response:", JSON.stringify(response.result));
+  } else {
+    throw response;
+  }
+}
+
+runExample().catch(console.error);

--- a/examples/tools-server/tsconfig.json
+++ b/examples/tools-server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "./src/**/*"
+  ],
+  "references": [
+    { "path": "../../" }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "zod": "^3.24.4"
+        "pkce-challenge": "^5.0.0",
+        "zod": "^3.24.4",
+        "zod-to-json-schema": "^3.24.5"
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
@@ -3485,6 +3487,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -4354,6 +4365,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,34 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
+    "build:examples": "tsc -p tsconfig.examples.json",
+    "build:all": "tsc && tsc -p tsconfig.examples.json",
     "test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest",
     "lint": "npx @biomejs/biome check src/",
-    "lint:format": "npx @biomejs/biome format src/ --write"
+    "lint:fix": "npx @biomejs/biome check src/ --fix",
+    "lint:fix-unsafe": "npx @biomejs/biome check src/ --fix --unsafe",
+    "format": "npx @biomejs/biome format src/ --write",
+    "example:ping": "node dist/examples/server/ping/index.js"
+  },
+  "files": [
+    "dist/**/**",
+    "docs/**/**",
+    "!**/*.spec.*",
+    "!**/*.test.*",
+    "!**/*.json",
+    "!**/*.tsbuildinfo",
+    "LICENSE",
+    "README.md"
+  ],
+  "exports": {
+    "./jsonrpc2/validation": {
+      "types": "./dist/jsonrpc2/validation.d.ts",
+      "import": "./dist/jsonrpc2/validation.js"
+    },
+    "./server": {
+      "types": "./dist/server/index.d.ts",
+      "import": "./dist/server/index.js"
+    }
   },
   "repository": {
     "type": "git",
@@ -28,6 +53,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "zod": "^3.24.4"
+    "zod": "^3.24.4",
+    "zod-to-json-schema": "^3.24.5"
   }
 }

--- a/src/jsonrpc2/schemas/error.ts
+++ b/src/jsonrpc2/schemas/error.ts
@@ -13,8 +13,8 @@
  */
 
 import { z } from "zod";
-import { JSONRPC_VERSION } from "../consts";
-import { IdSchema } from "./id";
+import { JSONRPC_VERSION } from "../consts.js";
+import { IdSchema } from "./id.js";
 
 /**
  * A response to a request that indicates an error occurred.

--- a/src/jsonrpc2/schemas/message.ts
+++ b/src/jsonrpc2/schemas/message.ts
@@ -13,10 +13,10 @@
  */
 
 import { z } from "zod";
-import { JSONRPCRequestSchema } from "./request";
-import { JSONRPCNotificationSchema } from "./notifications";
-import { JSONRPCResponseSchema } from "./response";
-import { JSONRPCErrorSchema } from "./error";
+import { JSONRPCErrorSchema } from "./error.js";
+import { JSONRPCNotificationSchema } from "./notifications.js";
+import { JSONRPCRequestSchema } from "./request.js";
+import { JSONRPCResponseSchema } from "./response.js";
 
 export const JSONRPCMessageSchema = z.union([
   JSONRPCRequestSchema,

--- a/src/jsonrpc2/schemas/notifications.ts
+++ b/src/jsonrpc2/schemas/notifications.ts
@@ -13,7 +13,7 @@
  */
 
 import { z } from "zod";
-import { JSONRPC_VERSION } from "../consts";
+import { JSONRPC_VERSION } from "../consts.js";
 
 export const BaseNotificationParamsSchema = z
   .object({

--- a/src/jsonrpc2/schemas/request.ts
+++ b/src/jsonrpc2/schemas/request.ts
@@ -13,8 +13,8 @@
  */
 
 import { z } from "zod";
-import { IdSchema } from "./id";
-import { JSONRPC_VERSION } from "../consts";
+import { JSONRPC_VERSION } from "../consts.js";
+import { IdSchema } from "./id.js";
 
 /**
  * A progress token, used to associate progress notifications with the original

--- a/src/jsonrpc2/schemas/response.ts
+++ b/src/jsonrpc2/schemas/response.ts
@@ -13,8 +13,8 @@
  */
 
 import { z } from "zod";
-import { IdSchema } from "./id";
-import { JSONRPC_VERSION } from "../consts";
+import { JSONRPC_VERSION } from "../consts.js";
+import { IdSchema } from "./id.js";
 
 export const ResultSchema = z
   .object({

--- a/src/jsonrpc2/types.ts
+++ b/src/jsonrpc2/types.ts
@@ -12,22 +12,25 @@
  * and is attributed to the original authors under the License.
  */
 
-import { z } from "zod";
-import {
+import type { z } from "zod";
+import type { CursorSchema } from "./schemas/cursor.js";
+import type { JSONRPCErrorSchema } from "./schemas/error.js";
+import type { IdSchema } from "./schemas/id.js";
+import type { JSONRPCMessageSchema } from "./schemas/message.js";
+import type {
+  JSONRPCNotificationSchema,
+  NotificationSchema,
+} from "./schemas/notifications.js";
+import type {
   JSONRPCRequestSchema,
   ProgressTokenSchema,
   RequestMetaSchema,
   RequestSchema,
-} from "./schemas/request";
-import {
-  JSONRPCNotificationSchema,
-  NotificationSchema,
-} from "./schemas/notifications";
-import { JSONRPCResponseSchema, ResultSchema } from "./schemas/response";
-import { JSONRPCErrorSchema } from "./schemas/error";
-import { JSONRPCMessageSchema } from "./schemas/message";
-import { CursorSchema } from "./schemas/cursor";
-import { IdSchema } from "./schemas/id";
+} from "./schemas/request.js";
+import type {
+  JSONRPCResponseSchema,
+  ResultSchema,
+} from "./schemas/response.js";
 
 /* JSON-RPC core types */
 export type ProgressToken = z.infer<typeof ProgressTokenSchema>;

--- a/src/jsonrpc2/validation.ts
+++ b/src/jsonrpc2/validation.ts
@@ -12,16 +12,16 @@
  * and is attributed to the original authors under the License.
  */
 
-import { JSONRPCErrorSchema } from "./schemas/error";
-import { JSONRPCNotificationSchema } from "./schemas/notifications";
-import { JSONRPCRequestSchema } from "./schemas/request";
-import { JSONRPCResponseSchema } from "./schemas/response";
-import {
+import { JSONRPCErrorSchema } from "./schemas/error.js";
+import { JSONRPCNotificationSchema } from "./schemas/notifications.js";
+import { JSONRPCRequestSchema } from "./schemas/request.js";
+import { JSONRPCResponseSchema } from "./schemas/response.js";
+import type {
   JSONRPCError,
   JSONRPCNotification,
   JSONRPCRequest,
   JSONRPCResponse,
-} from "./types";
+} from "./types.js";
 
 export const isJSONRPCRequest = (value: unknown): value is JSONRPCRequest =>
   JSONRPCRequestSchema.safeParse(value).success;

--- a/src/mcp/20250326/types/schemas/autocomplete.schema.ts
+++ b/src/mcp/20250326/types/schemas/autocomplete.schema.ts
@@ -16,8 +16,8 @@ import { z } from "zod";
 import {
   BaseRequestParamsSchema,
   RequestSchema,
-} from "../../../../jsonrpc2/schemas/request";
-import { ResultSchema } from "../../../../jsonrpc2/schemas/response";
+} from "../../../../jsonrpc2/schemas/request.js";
+import { ResultSchema } from "../../../../jsonrpc2/schemas/response.js";
 
 /**
  * A reference to a resource or resource template definition.

--- a/src/mcp/20250326/types/schemas/client.schema.ts
+++ b/src/mcp/20250326/types/schemas/client.schema.ts
@@ -13,33 +13,33 @@
  */
 
 import { z } from "zod";
-import { PingRequestSchema } from "./ping.schema";
+import { EmptyResultSchema } from "../../../../jsonrpc2/schemas/response.js";
 import { CompleteRequestSchema } from "./autocomplete.schema";
+import { InitializeRequestSchema } from "./initialize.schema";
 import { SetLevelRequestSchema } from "./logging.schema";
-import {
-  GetPromptRequestSchema,
-  ListPromptsRequestSchema,
-} from "./prompt.schema";
-import {
-  ListResourcesRequestSchema,
-  ListResourceTemplatesRequestSchema,
-  ReadResourceRequestSchema,
-  SubscribeRequestSchema,
-  UnsubscribeRequestSchema,
-} from "./resource.schema";
-import { CallToolRequestSchema, ListToolsRequestSchema } from "./tools.schema";
 import {
   CancelledNotificationSchema,
   InitializedNotificationSchema,
   ProgressNotificationSchema,
 } from "./notifications.schema";
+import { PingRequestSchema } from "./ping.schema";
+import {
+  GetPromptRequestSchema,
+  ListPromptsRequestSchema,
+} from "./prompt.schema";
+import {
+  ListResourceTemplatesRequestSchema,
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
+} from "./resource.schema";
 import {
   ListRootsResultSchema,
   RootsListChangedNotificationSchema,
 } from "./roots.schema";
-import { EmptyResultSchema } from "../../../../jsonrpc2/schemas/response";
 import { CreateMessageResultSchema } from "./sampling.schema";
-import { InitializeRequestSchema } from "./initialize.schema";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "./tools.schema";
 
 /**
  * Client requests union

--- a/src/mcp/20250326/types/schemas/content.schema.ts
+++ b/src/mcp/20250326/types/schemas/content.schema.ts
@@ -16,7 +16,7 @@ import { z } from "zod";
 import {
   BlobResourceContentsSchema,
   TextResourceContentsSchema,
-} from "./resource.schema";
+} from "./resource.schema.js";
 
 /**
  * Text provided to or from an LLM.

--- a/src/mcp/20250326/types/schemas/initialize.schema.ts
+++ b/src/mcp/20250326/types/schemas/initialize.schema.ts
@@ -16,13 +16,13 @@ import { z } from "zod";
 import {
   BaseRequestParamsSchema,
   RequestSchema,
-} from "../../../../jsonrpc2/schemas/request";
+} from "../../../../jsonrpc2/schemas/request.js";
+import { ResultSchema } from "../../../../jsonrpc2/schemas/response.js";
 import {
   ClientCapabilitiesSchema,
   ServerCapabilitiesSchema,
 } from "./capabilities.schema";
 import { ImplementationSchema } from "./implementation.schema";
-import { ResultSchema } from "../../../../jsonrpc2/schemas/response";
 
 /**
  * This request is sent from the client to the server when it first connects,

--- a/src/mcp/20250326/types/schemas/logging.schema.ts
+++ b/src/mcp/20250326/types/schemas/logging.schema.ts
@@ -14,13 +14,13 @@
 
 import { z } from "zod";
 import {
-  BaseRequestParamsSchema,
-  RequestSchema,
-} from "../../../../jsonrpc2/schemas/request";
-import {
   BaseNotificationParamsSchema,
   NotificationSchema,
-} from "../../../../jsonrpc2/schemas/notifications";
+} from "../../../../jsonrpc2/schemas/notifications.js";
+import {
+  BaseRequestParamsSchema,
+  RequestSchema,
+} from "../../../../jsonrpc2/schemas/request.js";
 
 /**
  * The severity of a log message.

--- a/src/mcp/20250326/types/schemas/notifications.schema.ts
+++ b/src/mcp/20250326/types/schemas/notifications.schema.ts
@@ -13,13 +13,13 @@
  */
 
 import { z } from "zod";
-import { ProgressSchema } from "./progress.schema";
-import { ProgressTokenSchema } from "../../../../jsonrpc2/schemas/request";
+import { IdSchema } from "../../../../jsonrpc2/schemas/id.js";
 import {
   BaseNotificationParamsSchema,
   NotificationSchema,
-} from "../../../../jsonrpc2/schemas/notifications";
-import { IdSchema } from "../../../../jsonrpc2/schemas/id";
+} from "../../../../jsonrpc2/schemas/notifications.js";
+import { ProgressTokenSchema } from "../../../../jsonrpc2/schemas/request.js";
+import { ProgressSchema } from "./progress.schema.js";
 
 /**
  * This notification can be sent by either side to indicate that it is

--- a/src/mcp/20250326/types/schemas/pagination.schema.ts
+++ b/src/mcp/20250326/types/schemas/pagination.schema.ts
@@ -13,12 +13,12 @@
  */
 
 import { z } from "zod";
+import { CursorSchema } from "../../../../jsonrpc2/schemas/cursor.js";
 import {
   BaseRequestParamsSchema,
   RequestSchema,
-} from "../../../../jsonrpc2/schemas/request";
-import { CursorSchema } from "../../../../jsonrpc2/schemas/cursor";
-import { ResultSchema } from "../../../../jsonrpc2/schemas/response";
+} from "../../../../jsonrpc2/schemas/request.js";
+import { ResultSchema } from "../../../../jsonrpc2/schemas/response.js";
 
 export const PaginatedRequestSchema = RequestSchema.extend({
   params: BaseRequestParamsSchema.extend({
@@ -32,7 +32,7 @@ export const PaginatedRequestSchema = RequestSchema.extend({
 
 export const PaginatedResultSchema = ResultSchema.extend({
   /**
-   * An opaque token representing the pagination position after the last returned 
+   * An opaque token representing the pagination position after the last returned
    * result. If present, there may be more results available.
    */
   nextCursor: z.optional(CursorSchema),

--- a/src/mcp/20250326/types/schemas/ping.schema.ts
+++ b/src/mcp/20250326/types/schemas/ping.schema.ts
@@ -13,7 +13,7 @@
  */
 
 import { z } from "zod";
-import { RequestSchema } from "../../../../jsonrpc2/schemas/request";
+import { RequestSchema } from "../../../../jsonrpc2/schemas/request.js";
 
 /**
  * A ping, issued by either the server or the client, to check that the other

--- a/src/mcp/20250326/types/schemas/prompt.schema.ts
+++ b/src/mcp/20250326/types/schemas/prompt.schema.ts
@@ -13,22 +13,22 @@
  */
 
 import { z } from "zod";
-import {
-  PaginatedRequestSchema,
-  PaginatedResultSchema,
-} from "./pagination.schema";
+import { NotificationSchema } from "../../../../jsonrpc2/schemas/notifications.js";
 import {
   BaseRequestParamsSchema,
   RequestSchema,
-} from "../../../../jsonrpc2/schemas/request";
-import { ResultSchema } from "../../../../jsonrpc2/schemas/response";
+} from "../../../../jsonrpc2/schemas/request.js";
+import { ResultSchema } from "../../../../jsonrpc2/schemas/response.js";
 import {
   AudioContentSchema,
   EmbeddedResourceSchema,
   ImageContentSchema,
   TextContentSchema,
-} from "./content.schema";
-import { NotificationSchema } from "../../../../jsonrpc2/schemas/notifications";
+} from "./content.schema.js";
+import {
+  PaginatedRequestSchema,
+  PaginatedResultSchema,
+} from "./pagination.schema.js";
 
 /**
  * Describes an argument that a prompt can accept.

--- a/src/mcp/20250326/types/schemas/resource.schema.ts
+++ b/src/mcp/20250326/types/schemas/resource.schema.ts
@@ -14,18 +14,18 @@
 
 import { z } from "zod";
 import {
-  PaginatedRequestSchema,
-  PaginatedResultSchema,
-} from "./pagination.schema";
+  BaseNotificationParamsSchema,
+  NotificationSchema,
+} from "../../../../jsonrpc2/schemas/notifications.js";
 import {
   BaseRequestParamsSchema,
   RequestSchema,
-} from "../../../../jsonrpc2/schemas/request";
-import { ResultSchema } from "../../../../jsonrpc2/schemas/response";
+} from "../../../../jsonrpc2/schemas/request.js";
+import { ResultSchema } from "../../../../jsonrpc2/schemas/response.js";
 import {
-  BaseNotificationParamsSchema,
-  NotificationSchema,
-} from "../../../../jsonrpc2/schemas/notifications";
+  PaginatedRequestSchema,
+  PaginatedResultSchema,
+} from "./pagination.schema.js";
 
 /* Resources */
 

--- a/src/mcp/20250326/types/schemas/roots.schema.ts
+++ b/src/mcp/20250326/types/schemas/roots.schema.ts
@@ -13,9 +13,9 @@
  */
 
 import { z } from "zod";
-import { RequestSchema } from "../../../../jsonrpc2/schemas/request";
-import { ResultSchema } from "../../../../jsonrpc2/schemas/response";
-import { NotificationSchema } from "../../../../jsonrpc2/schemas/notifications";
+import { NotificationSchema } from "../../../../jsonrpc2/schemas/notifications.js";
+import { RequestSchema } from "../../../../jsonrpc2/schemas/request.js";
+import { ResultSchema } from "../../../../jsonrpc2/schemas/response.js";
 
 /* Roots */
 

--- a/src/mcp/20250326/types/schemas/sampling.schema.ts
+++ b/src/mcp/20250326/types/schemas/sampling.schema.ts
@@ -14,15 +14,15 @@
 
 import { z } from "zod";
 import {
+  BaseRequestParamsSchema,
+  RequestSchema,
+} from "../../../../jsonrpc2/schemas/request.js";
+import { ResultSchema } from "../../../../jsonrpc2/schemas/response.js";
+import {
   AudioContentSchema,
   ImageContentSchema,
   TextContentSchema,
-} from "./content.schema";
-import {
-  BaseRequestParamsSchema,
-  RequestSchema,
-} from "../../../../jsonrpc2/schemas/request";
-import { ResultSchema } from "../../../../jsonrpc2/schemas/response";
+} from "./content.schema.js";
 
 /**
  * Hints to use for model selection.

--- a/src/mcp/20250326/types/schemas/server.schema.ts
+++ b/src/mcp/20250326/types/schemas/server.schema.ts
@@ -13,34 +13,34 @@
  */
 
 import { z } from "zod";
-import { PingRequestSchema } from "./ping.schema";
-import { CreateMessageRequestSchema } from "./sampling.schema";
-import { ListRootsRequestSchema } from "./roots.schema";
+import { EmptyResultSchema } from "../../../../jsonrpc2/schemas/response.js";
+import { CompleteResultSchema } from "./autocomplete.schema.js";
+import { InitializeResultSchema } from "./initialize.schema.js";
+import { LoggingMessageNotificationSchema } from "./logging.schema.js";
 import {
   CancelledNotificationSchema,
   ProgressNotificationSchema,
 } from "./notifications.schema";
-import { LoggingMessageNotificationSchema } from "./logging.schema";
-import {
-  ListResourcesResultSchema,
-  ListResourceTemplatesResultSchema,
-  ReadResourceResultSchema,
-  ResourceListChangedNotificationSchema,
-  ResourceUpdatedNotificationSchema,
-} from "./resource.schema";
-import {
-  CallToolResultSchema,
-  ListToolsResultSchema,
-  ToolListChangedNotificationSchema,
-} from "./tools.schema";
+import { PingRequestSchema } from "./ping.schema";
 import {
   GetPromptResultSchema,
   ListPromptsResultSchema,
   PromptListChangedNotificationSchema,
 } from "./prompt.schema";
-import { EmptyResultSchema } from "../../../../jsonrpc2/schemas/response";
-import { CompleteResultSchema } from "./autocomplete.schema";
-import { InitializeResultSchema } from "./initialize.schema";
+import {
+  ListResourceTemplatesResultSchema,
+  ListResourcesResultSchema,
+  ReadResourceResultSchema,
+  ResourceListChangedNotificationSchema,
+  ResourceUpdatedNotificationSchema,
+} from "./resource.schema";
+import { ListRootsRequestSchema } from "./roots.schema";
+import { CreateMessageRequestSchema } from "./sampling.schema";
+import {
+  CallToolResultSchema,
+  ListToolsResultSchema,
+  ToolListChangedNotificationSchema,
+} from "./tools.schema";
 
 /**
  * Server request unions

--- a/src/mcp/20250326/types/schemas/tools.schema.ts
+++ b/src/mcp/20250326/types/schemas/tools.schema.ts
@@ -13,22 +13,22 @@
  */
 
 import { z } from "zod";
+import { NotificationSchema } from "../../../../jsonrpc2/schemas/notifications.js";
 import {
-  PaginatedRequestSchema,
-  PaginatedResultSchema,
-} from "./pagination.schema";
-import { ResultSchema } from "../../../../jsonrpc2/schemas/response";
+  BaseRequestParamsSchema,
+  RequestSchema,
+} from "../../../../jsonrpc2/schemas/request.js";
+import { ResultSchema } from "../../../../jsonrpc2/schemas/response.js";
 import {
   AudioContentSchema,
   EmbeddedResourceSchema,
   ImageContentSchema,
   TextContentSchema,
-} from "./content.schema";
+} from "./content.schema.js";
 import {
-  BaseRequestParamsSchema,
-  RequestSchema,
-} from "../../../../jsonrpc2/schemas/request";
-import { NotificationSchema } from "../../../../jsonrpc2/schemas/notifications";
+  PaginatedRequestSchema,
+  PaginatedResultSchema,
+} from "./pagination.schema.js";
 
 /**
  * Additional properties describing a Tool to clients.

--- a/src/mcp/20250326/types/types.ts
+++ b/src/mcp/20250326/types/types.ts
@@ -12,31 +12,67 @@
  * and is attributed to the original authors under the License.
  */
 
-import { z } from "zod";
+import type { z } from "zod";
 
-import { ImplementationSchema } from "./schemas/implementation.schema";
-import {
+import type { EmptyResultSchema } from "../../../jsonrpc2/schemas/response.js";
+import type {
+  CompleteRequestSchema,
+  CompleteResultSchema,
+  PromptReferenceSchema,
+  ResourceReferenceSchema,
+} from "./schemas/autocomplete.schema.js";
+import type {
+  ClientCapabilitiesSchema,
+  ServerCapabilitiesSchema,
+} from "./schemas/capabilities.schema.js";
+import type {
+  ClientNotificationSchema,
+  ClientRequestSchema,
+  ClientResultSchema,
+} from "./schemas/client.schema.js";
+import type {
+  AudioContentSchema,
+  EmbeddedResourceSchema,
+  ImageContentSchema,
+  TextContentSchema,
+} from "./schemas/content.schema.js";
+import type { ImplementationSchema } from "./schemas/implementation.schema.js";
+import type {
+  InitializeRequestSchema,
+  InitializeResultSchema,
+} from "./schemas/initialize.schema.js";
+import type {
+  LoggingLevelSchema,
+  LoggingMessageNotificationSchema,
+  SetLevelRequestSchema,
+} from "./schemas/logging.schema.js";
+import type {
   CancelledNotificationSchema,
   InitializedNotificationSchema,
   ProgressNotificationSchema,
-} from "./schemas/notifications.schema";
-import {
-  ClientCapabilitiesSchema,
-  ServerCapabilitiesSchema,
-} from "./schemas/capabilities.schema";
-import { EmptyResultSchema } from "../../../jsonrpc2/schemas/response";
-import { PingRequestSchema } from "./schemas/ping.schema";
-import { ProgressSchema } from "./schemas/progress.schema";
-import {
+} from "./schemas/notifications.schema.js";
+import type {
   PaginatedRequestSchema,
   PaginatedResultSchema,
-} from "./schemas/pagination.schema";
-import {
+} from "./schemas/pagination.schema.js";
+import type { PingRequestSchema } from "./schemas/ping.schema.js";
+import type { ProgressSchema } from "./schemas/progress.schema.js";
+import type {
+  GetPromptRequestSchema,
+  GetPromptResultSchema,
+  ListPromptsRequestSchema,
+  ListPromptsResultSchema,
+  PromptArgumentSchema,
+  PromptListChangedNotificationSchema,
+  PromptMessageSchema,
+  PromptSchema,
+} from "./schemas/prompt.schema.js";
+import type {
   BlobResourceContentsSchema,
-  ListResourcesRequestSchema,
-  ListResourcesResultSchema,
   ListResourceTemplatesRequestSchema,
   ListResourceTemplatesResultSchema,
+  ListResourcesRequestSchema,
+  ListResourcesResultSchema,
   ReadResourceRequestSchema,
   ReadResourceResultSchema,
   ResourceContentsSchema,
@@ -47,24 +83,24 @@ import {
   SubscribeRequestSchema,
   TextResourceContentsSchema,
   UnsubscribeRequestSchema,
-} from "./schemas/resource.schema";
-import {
-  GetPromptRequestSchema,
-  GetPromptResultSchema,
-  ListPromptsRequestSchema,
-  ListPromptsResultSchema,
-  PromptArgumentSchema,
-  PromptListChangedNotificationSchema,
-  PromptMessageSchema,
-  PromptSchema,
-} from "./schemas/prompt.schema";
-import {
-  AudioContentSchema,
-  EmbeddedResourceSchema,
-  ImageContentSchema,
-  TextContentSchema,
-} from "./schemas/content.schema";
-import {
+} from "./schemas/resource.schema.js";
+import type {
+  ListRootsRequestSchema,
+  ListRootsResultSchema,
+  RootSchema,
+  RootsListChangedNotificationSchema,
+} from "./schemas/roots.schema.js";
+import type {
+  CreateMessageRequestSchema,
+  CreateMessageResultSchema,
+  SamplingMessageSchema,
+} from "./schemas/sampling.schema.js";
+import type {
+  ServerNotificationSchema,
+  ServerRequestSchema,
+  ServerResultSchema,
+} from "./schemas/server.schema.js";
+import type {
   CallToolRequestSchema,
   CallToolResultSchema,
   CompatibilityCallToolResultSchema,
@@ -73,43 +109,7 @@ import {
   ToolAnnotationsSchema,
   ToolListChangedNotificationSchema,
   ToolSchema,
-} from "./schemas/tools.schema";
-import {
-  LoggingLevelSchema,
-  LoggingMessageNotificationSchema,
-  SetLevelRequestSchema,
-} from "./schemas/logging.schema";
-import {
-  CreateMessageRequestSchema,
-  CreateMessageResultSchema,
-  SamplingMessageSchema,
-} from "./schemas/sampling.schema";
-import {
-  CompleteRequestSchema,
-  CompleteResultSchema,
-  PromptReferenceSchema,
-  ResourceReferenceSchema,
-} from "./schemas/autocomplete.schema";
-import {
-  ListRootsRequestSchema,
-  ListRootsResultSchema,
-  RootSchema,
-  RootsListChangedNotificationSchema,
-} from "./schemas/roots.schema";
-import {
-  ClientNotificationSchema,
-  ClientRequestSchema,
-  ClientResultSchema,
-} from "./schemas/client.schema";
-import {
-  ServerNotificationSchema,
-  ServerRequestSchema,
-  ServerResultSchema,
-} from "./schemas/server.schema";
-import {
-  InitializeRequestSchema,
-  InitializeResultSchema,
-} from "./schemas/initialize.schema";
+} from "./schemas/tools.schema.js";
 
 /* Initialization */
 export type Implementation = z.infer<typeof ImplementationSchema>;

--- a/src/mcp/20250326/types/validation.ts
+++ b/src/mcp/20250326/types/validation.ts
@@ -12,9 +12,9 @@
  * and is attributed to the original authors under the License.
  */
 
-import { InitializeRequestSchema } from "./schemas/initialize.schema";
-import { InitializedNotificationSchema } from "./schemas/notifications.schema";
-import { InitializedNotification, InitializeRequest } from "./types";
+import { InitializeRequestSchema } from "./schemas/initialize.schema.js";
+import { InitializedNotificationSchema } from "./schemas/notifications.schema.js";
+import type { InitializeRequest, InitializedNotification } from "./types.js";
 
 export const isInitializeRequest = (
   value: unknown

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,0 +1,282 @@
+import { AnyZodObject, type ZodSchema, z } from "zod";
+import zodToJsonSchema from "zod-to-json-schema";
+import type {
+  JSONRPCError,
+  JSONRPCNotification,
+  JSONRPCRequest,
+  JSONRPCResponse,
+} from "../jsonrpc2/types.js";
+import { CallToolRequestSchema } from "../mcp/20250326/types/schemas/tools.schema.js";
+import type { ServerResult, ServerCapabilities, Tool } from "../mcp/20250326/types/types.js";
+import type { MCPServerOptions, RegisteredTool, ToolHandler } from "./types.js";
+
+export class MCPServer {
+  private capabilities: ServerCapabilities;
+  private tools: Map<string, RegisteredTool<any, any>> = new Map();
+  private name: string;
+  private version: string;
+
+  constructor(options: MCPServerOptions) {
+    this.name = options.name || "MCP Server";
+    this.version = options.version || "1.0.0";
+
+    // Set default capabilities
+    this.capabilities = {
+      ping: true,
+      tools: {
+        supported: true,
+        available: [],
+      },
+      ...options.capabilities,
+    };
+  }
+
+  getTool(name: string): Tool | undefined {
+    throw new Error("Method not implemented.");
+  }
+
+  getTools(): Map<string, Tool> {
+    throw new Error("Method not implemented.");
+  }
+
+  /**
+   * Get the server capabilities
+   */
+  public getCapabilities(): ServerCapabilities {
+    return { ...this.capabilities };
+  }
+
+  /**
+   * Register a tool
+   */
+  public addTool<S extends ZodSchema, R = unknown>(
+    name: string,
+    paramSchema: S,
+    handler: ToolHandler<S, R>,
+    description = `Execute the ${name} tool`
+  ): void {
+    // Create tool schema from zod schema
+    const toolSchema: Tool = {
+      name,
+      description,
+      inputSchema: zodToJsonSchema(paramSchema) as Tool["inputSchema"],
+    };
+
+    const registeredTool: RegisteredTool<S, R> = {
+      toolSchema: toolSchema,
+      inputSchema: paramSchema,
+      handler,
+    };
+
+    this.tools.set(name, registeredTool);
+    this.updateAvailableTools();
+
+    return;
+  }
+
+  /**
+   * Remove a tool from the server
+   */
+  public removeTool(name: string): boolean {
+    const result = this.tools.delete(name);
+
+    if (result) {
+      this.updateAvailableTools();
+    }
+
+    return result;
+  }
+
+  /**
+   * Get all registered tools
+   */
+  public getToolDefinitions(): Tool[] {
+    return Array.from(this.tools.values()).map((tool) => tool.toolSchema);
+  }
+
+  /**
+   * Handle a JSON-RPC request
+   */
+  public async handleRequest(
+    request: JSONRPCRequest
+  ): Promise<JSONRPCResponse | JSONRPCError> {
+    try {
+      // Handle built-in methods
+      if (request.method === "ping") {
+        return this.handlePing(request);
+      }
+      if (request.method === "initialize") {
+        return this.handleInitialize(request);
+      }
+      if (request.method === "tools/call") {
+        return this.handleToolRequest(request);
+      }
+
+      // Method not found
+      return {
+        jsonrpc: "2.0",
+        id: request.id,
+        error: {
+          code: -32601,
+          message: `Method "${request.method}" not found`,
+        },
+      };
+    } catch (error) {
+      console.error("Error handling request:", error);
+
+      // Internal error
+      return {
+        jsonrpc: "2.0",
+        id: request.id,
+        error: {
+          code: -32603,
+          message: error instanceof Error ? error.message : "Internal error",
+        },
+      };
+    }
+  }
+
+  /**
+   * Handle a JSON-RPC notification
+   */
+  public async handleNotification(
+    notification: JSONRPCNotification
+  ): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+
+  /**
+   * Handle ping request
+   */
+  private handlePing(request: JSONRPCRequest): JSONRPCResponse | JSONRPCError {
+    if (!this.capabilities.ping) {
+      return {
+        jsonrpc: "2.0",
+        id: request.id,
+        error: {
+          code: -32601,
+          message: "Method 'ping' not supported",
+        },
+      };
+    }
+
+    return {
+      jsonrpc: "2.0",
+      id: request.id,
+      result: {
+        pong: true,
+      },
+    };
+  }
+
+  /**
+   * Handle initialize request
+   */
+  private handleInitialize(request: JSONRPCRequest): JSONRPCResponse {
+    // Return initialization result with server capabilities
+    return {
+      jsonrpc: "2.0",
+      id: request.id,
+      result: {
+        server: {
+          name: this.name,
+          version: this.version,
+        },
+        capabilities: this.getCapabilities(),
+      },
+    };
+  }
+
+  /**
+   * Handle tool request
+   */
+  private async handleToolRequest(
+    request: JSONRPCRequest
+  ): Promise<JSONRPCResponse | JSONRPCError> {
+    const validatedToolCall = CallToolRequestSchema.safeParse(request);
+    if (!validatedToolCall.success) {
+      console.log("could not validate tool call with calltoolrequestschema");
+      return {
+        jsonrpc: "2.0",
+        id: request.id,
+        error: {
+          code: -32600,
+          message: `Invalid request ${validatedToolCall.error}`,
+        },
+      };
+    }
+
+    const toolCallReq = validatedToolCall.data;
+    console.log("toolCallReq data", toolCallReq);
+    const toolName = toolCallReq.params.name;
+    console.log("tool name", toolName);
+
+    const tool = this.tools.get(toolName);
+    if (!tool) {
+      return {
+        jsonrpc: "2.0",
+        id: request.id,
+        error: {
+          code: -32601,
+          message: `Tool "${toolName}" not found`,
+        },
+      };
+    }
+
+    // Validate parameters if schema is available
+    const params = toolCallReq.params.arguments || {};
+    let validatedParams = z.object({});
+
+    if (tool.inputSchema) {
+      const parsed = tool.inputSchema.safeParse(params);
+      if (!parsed.success) {
+        return {
+          jsonrpc: "2.0",
+          id: request.id,
+          error: {
+            code: -32602,
+            message: "Invalid params",
+            data: parsed.error,
+          },
+        };
+      }
+
+      validatedParams = parsed.data;
+    }
+
+    // Execute the tool
+    try {
+      const result = await tool.handler(validatedParams);
+      const serverResponse: ServerResult = {
+        content: result,
+        isError: false
+      }
+      return {
+        jsonrpc: "2.0",
+        id: request.id,
+        result: serverResponse,
+      };
+    } catch (error) {
+      console.error(`Error executing tool "${toolName}":`, error);
+
+      return {
+        jsonrpc: "2.0",
+        id: request.id,
+        error: {
+          code: -32603,
+          message:
+            error instanceof Error ? error.message : "Tool execution error",
+        },
+      };
+    }
+  }
+
+  /**
+   * Update the available tools in capabilities
+   */
+  private updateAvailableTools(): void {
+    if (this.capabilities.tools) {
+      this.capabilities.tools.available = Array.from(this.tools.keys());
+    }
+  }
+}

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -1,0 +1,38 @@
+import type { ZodSchema, z } from "zod";
+import type { ServerCapabilities, Tool } from "../mcp/20250326/types/types.js";
+
+/**
+ * Handler function for tool execution
+ */
+export type ToolHandler<S extends ZodSchema, R = unknown> = (
+  params: z.infer<S>
+) => Promise<R> | R;
+
+/**
+ * Internal storage type for registered tools
+ */
+export type RegisteredTool<S extends ZodSchema = ZodSchema, R = unknown> = {
+  toolSchema: Tool;
+  inputSchema: S;
+  handler: ToolHandler<S, R>;
+};
+
+/**
+ * Server options for configuration
+ */
+export interface MCPServerOptions {
+  /**
+   * Server name
+   */
+  name: string;
+
+  /**
+   * Server version
+   */
+  version: string;
+
+  /**
+   * Custom capabilities (will be merged with defaults)
+   */
+  capabilities?: ServerCapabilities;
+}

--- a/src/transport/httpstreamable.ts
+++ b/src/transport/httpstreamable.ts
@@ -1,0 +1,692 @@
+import type {
+  JSONRPCMessage,
+  JSONRPCRequest,
+  JSONRPCResponse,
+} from "../jsonrpc2/types.ts";
+import { isJSONRPCRequest, isJSONRPCResponse } from "../jsonrpc2/validation.js";
+import type { MessageHandler, Transport, TransportOptions } from "./types.js";
+
+/**
+ * Handler for streaming responses
+ */
+export interface StreamProvider {
+  getStream(): AsyncIterable<JSONRPCMessage>;
+  cancel?(): void;
+}
+
+/**
+ * Session information
+ */
+interface Session {
+  id: string;
+  createdAt: number;
+  lastActivity: number;
+  streams: Map<string, StreamInfo>;
+  lastEventId?: string;
+}
+
+/**
+ * Stream information for tracking server-sent events
+ */
+interface StreamInfo {
+  id: string;
+  writer: WritableStreamDefaultWriter<Uint8Array>;
+  eventCounter: number;
+  messages: JSONRPCMessage[];
+  pendingRequests: Set<string | number>; // IDs of requests waiting for responses
+}
+
+/**
+ * HTTP Streamable Transport implementation for Model Context Protocol
+ * following the Streamable HTTP transport specification
+ */
+export class HTTPStreamableTransport implements Transport {
+  messageHandler: MessageHandler | null = null;
+  closeCallback: (() => void) | null = null;
+
+  private options: TransportOptions;
+  private connected = false;
+  private sessions: Map<string, Session> = new Map();
+  private streams: Map<string, StreamInfo> = new Map();
+
+  constructor(options: TransportOptions = {}, streamable = false) {
+    // Set defaults
+    this.options = {
+      timeout: 30 * 60 * 1000, // 30 minutes
+      enableSessions: false,
+      ...options,
+    };
+
+    // Start session cleanup timer if sessions are enabled
+    if (streamable) {
+      this.startSessionCleanup();
+    }
+  }
+
+  onError(callback: (error: Error) => void): void {
+    throw new Error("Method not implemented.");
+  }
+
+  getSessionId(): string | undefined {
+    throw new Error("Method not implemented.");
+  }
+
+  setSessionId(sessionId: string | undefined): void {
+    throw new Error("Method not implemented.");
+  }
+
+  /**
+   * Initialize the transport with the server
+   */
+  public async connect(): Promise<void> {
+    this.connected = true;
+  }
+
+  /**
+   * Send a JSON RPC Message on the connected transport
+   * This sends messages to connected SSE streams
+   */
+  public async send(message: JSONRPCMessage): Promise<void> {
+    if (!this.connected) {
+      throw new Error("Transport not connected");
+    }
+
+    // Determine target session and stream based on message
+    if (isJSONRPCResponse(message)) {
+      // Find stream waiting for this response
+      for (const [sessionId, session] of this.sessions.entries()) {
+        for (const [streamId, streamInfo] of session.streams.entries()) {
+          if (streamInfo.pendingRequests.has(message.id)) {
+            // Send response on this stream
+            await this.sendToStream(streamInfo, message);
+            streamInfo.pendingRequests.delete(message.id);
+
+            // If this was the last pending request, close the stream
+            if (streamInfo.pendingRequests.size === 0) {
+              await this.closeStream(sessionId, streamId);
+            }
+            return;
+          }
+        }
+      }
+    } else {
+      // For requests or notifications, send to all active sessions
+      // (In practice, you might want a more sophisticated routing mechanism)
+      for (const session of this.sessions.values()) {
+        // Use the first available stream for this session
+        const streamInfo = [...session.streams.values()][0];
+        if (streamInfo) {
+          await this.sendToStream(streamInfo, message);
+
+          // If it's a request, track it for future response matching
+          if (isJSONRPCRequest(message)) {
+            streamInfo.pendingRequests.add(message.id);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Set message handler callback
+   */
+  public onMessage(handler: MessageHandler): void {
+    this.messageHandler = handler;
+  }
+
+  /**
+   * Sets a callback for when the transport is closed
+   */
+  public onClose(callback: () => void): void {
+    this.closeCallback = callback;
+  }
+
+  /**
+   * Close the transport
+   */
+  public async close(): Promise<void> {
+    this.connected = false;
+
+    // Close all streams
+    for (const session of this.sessions.values()) {
+      for (const [streamId, streamInfo] of session.streams.entries()) {
+        try {
+          await streamInfo.writer.close();
+        } catch (error) {
+          console.warn("Error closing stream:", error);
+        }
+      }
+      session.streams.clear();
+    }
+
+    // Clear all sessions
+    this.sessions.clear();
+
+    if (this.closeCallback) {
+      this.closeCallback();
+    }
+  }
+
+  /**
+   * Handle HTTP request (follows the WinterTC standard)
+   */
+  public async handleRequest(request: Request): Promise<Response> {
+    if (!this.connected) {
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          error: {
+            code: -32000,
+            message: "Transport not connected",
+          },
+          id: null,
+        }),
+        {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    if (!this.messageHandler) {
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          error: {
+            code: -32000,
+            message: "No message handler registered",
+          },
+          id: null,
+        }),
+        {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Process based on HTTP method
+    const method = request.method.toUpperCase();
+
+    try {
+      // Validate origin for security
+      this.validateOrigin(request);
+
+      // Extract session ID if present
+      const sessionId = request.headers.get("Mcp-Session-Id");
+      let session: Session | undefined;
+
+      if (sessionId) {
+        session = this.sessions.get(sessionId);
+        if (!session && method !== "DELETE") {
+          // Session not found or expired
+          return new Response(null, { status: 404 });
+        }
+      }
+
+      switch (method) {
+        case "POST":
+          return await this.handlePostRequest(request, session);
+
+        case "GET":
+          return await this.handleGetRequest(request, session);
+
+        case "DELETE":
+          return await this.handleDeleteRequest(request, session?.id);
+
+        default:
+          return new Response(null, {
+            status: 405,
+            headers: { Allow: "POST, GET, DELETE" },
+          });
+      }
+    } catch (error) {
+      console.error("Error handling request:", error);
+
+      // Determine appropriate status code
+      const status = 400;
+
+      const errorResponse = {
+        jsonrpc: "2.0",
+        error: {
+          code: -32603, // Internal error
+          message: error || "Server error",
+        },
+        id: null,
+      };
+
+      return new Response(JSON.stringify(errorResponse), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+  }
+
+  /**
+   * Handle POST requests (sending messages to server)
+   */
+  private async handlePostRequest(
+    request: Request,
+    session?: Session
+  ): Promise<Response> {
+    // Check Accept header as required by the spec
+    const acceptHeader = request.headers.get("Accept") || "";
+    if (
+      !acceptHeader.includes("application/json") &&
+      !acceptHeader.includes("text/event-stream")
+    ) {
+      return new Response(null, {
+        status: 406, // Not Acceptable
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Extract JSON-RPC message(s) from request
+    const messages = await this.extractJSONRPC(request);
+    if (!messages || (Array.isArray(messages) && messages.length === 0)) {
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          error: { code: -32700, message: "Parse error" },
+          id: null,
+        }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Normalize to array of messages
+    const messageArray = Array.isArray(messages) ? messages : [messages];
+
+    // Check if this contains any requests
+    const hasRequests = messageArray.some((msg) => this.isRequest(msg));
+    const onlyNotificationsOrResponses = !hasRequests;
+
+    // Handle session initialization
+    if (
+      this.options.enableSessions &&
+      !session &&
+      messageArray.some(
+        (msg) => this.isRequest(msg) && msg.method === "initialize"
+      )
+    ) {
+      // Create new session
+      const sessionId = this.generateFallbackUUID();
+      session = this.createSession(sessionId);
+    }
+
+    // Process messages
+    try {
+      // For messages that are only notifications or responses
+      if (onlyNotificationsOrResponses) {
+        for (const message of messageArray) {
+          await this.messageHandler?.(message);
+        }
+        return new Response(null, {
+          status: 202,
+          headers: session ? { "Mcp-Session-Id": session.id } : undefined,
+        });
+      }
+
+      // For requests or batches containing requests
+      // Create SSE stream for responses
+      const { stream, streamId } = this.createStream(session);
+      const responsePromises: Promise<JSONRPCResponse | undefined>[] = [];
+
+      for (const message of messageArray) {
+        if (this.isRequest(message)) {
+          // Track this request ID in the stream
+          this.streams.get(streamId)?.pendingRequests.add(message.id);
+
+          // Process the request
+          const responsePromise = this.messageHandler?.(
+            message
+          ) as Promise<JSONRPCResponse>;
+          responsePromises.push(responsePromise);
+        } else {
+          // Process notification or response
+          await this.messageHandler?.(message);
+        }
+      }
+
+      // Decide if we want to use SSE or direct response
+      // For simplicity, always use SSE if there are requests
+      // (A more sophisticated implementation might optimize for single-request cases)
+      const headers: Record<string, string> = {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      };
+
+      if (session) {
+        headers["Mcp-Session-Id"] = session.id;
+      }
+
+      // Let responses be handled by the message handler and sent to the stream
+      return new Response(stream.readable, { headers });
+    } catch (error) {
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          error: { code: -32603, message: error || "Internal error" },
+          id: null,
+        }),
+        {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }
+  }
+
+  /**
+   * Handle GET requests (listening for server messages)
+   */
+  private async handleGetRequest(
+    request: Request,
+    session?: Session
+  ): Promise<Response> {
+    // Check Accept header as required by the spec
+    const acceptHeader = request.headers.get("Accept") || "";
+    if (!acceptHeader.includes("text/event-stream")) {
+      return new Response(null, {
+        status: 406, // Not Acceptable
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // If no session and sessions are required, reject
+    if (this.options.enableSessions && !session) {
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          error: { code: -32000, message: "Session required" },
+          id: null,
+        }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Create a new stream for server-to-client communication
+    const { stream, streamId } = this.createStream(session);
+
+    // Check for Last-Event-ID for resumability
+    const lastEventId = request.headers.get("Last-Event-ID");
+    if (lastEventId && session) {
+      // Replay messages if needed
+      await this.replayMessages(session, streamId, lastEventId);
+    }
+
+    // Return the stream
+    const headers: Record<string, string> = {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    };
+
+    if (session) {
+      headers["Mcp-Session-Id"] = session.id;
+    }
+
+    return new Response(stream.readable, { headers });
+  }
+
+  /**
+   * Handle DELETE requests (explicit session termination)
+   */
+  private async handleDeleteRequest(
+    request: Request,
+    sessionId?: string
+  ): Promise<Response> {
+    if (!sessionId) {
+      return new Response(null, { status: 400 });
+    }
+
+    if (this.options.enableSessions && sessionId) {
+      // Remove the session
+      const session = this.sessions.get(sessionId);
+      if (session) {
+        // Close all streams
+        for (const [streamId, streamInfo] of session.streams.entries()) {
+          await this.closeStream(sessionId, streamId);
+        }
+
+        // Delete the session
+        this.sessions.delete(sessionId);
+        return new Response(null, { status: 204 });
+      }
+    }
+
+    // Session not found
+    return new Response(null, { status: 404 });
+  }
+
+  /**
+   * Send message to a specific stream
+   */
+  private async sendToStream(
+    streamInfo: StreamInfo,
+    message: JSONRPCMessage
+  ): Promise<void> {
+    try {
+      const eventId = String(++streamInfo.eventCounter);
+      const eventData = JSON.stringify(message);
+
+      // Store message for potential replay
+      streamInfo.messages.push(message);
+
+      // Keep message history manageable
+      if (streamInfo.messages.length > 100) {
+        // Arbitrary limit, adjust as needed
+        streamInfo.messages.shift();
+      }
+
+      // Format as SSE event
+      const event = `id: ${eventId}\ndata: ${eventData}\n\n`;
+      await streamInfo.writer.write(new TextEncoder().encode(event));
+    } catch (error) {
+      console.warn("Error sending to stream:", error);
+      // Stream might be closed, but we don't throw to avoid breaking the send loop
+    }
+  }
+
+  /**
+   * Close a specific stream
+   */
+  private async closeStream(
+    sessionId: string,
+    streamId: string
+  ): Promise<void> {
+    const session = this.sessions.get(sessionId);
+    if (!session) return;
+
+    const streamInfo = session.streams.get(streamId);
+    if (!streamInfo) return;
+
+    try {
+      await streamInfo.writer.close();
+    } catch (error) {
+      console.warn("Error closing stream:", error);
+    }
+
+    session.streams.delete(streamId);
+    this.streams.delete(streamId);
+  }
+
+  /**
+   * Create a new session
+   */
+  private createSession(sessionId: string): Session {
+    const session: Session = {
+      id: sessionId,
+      createdAt: Date.now(),
+      lastActivity: Date.now(),
+      streams: new Map(),
+    };
+
+    this.sessions.set(sessionId, session);
+    return session;
+  }
+
+  /**
+   * Create a new stream for SSE communication
+   */
+  private createStream(session?: Session): {
+    stream: TransformStream;
+    streamId: string;
+  } {
+    const stream = new TransformStream();
+    const writer = stream.writable.getWriter();
+    const streamId = crypto.randomUUID?.() || this.generateFallbackUUID();
+
+    const streamInfo: StreamInfo = {
+      id: streamId,
+      writer,
+      eventCounter: 0,
+      messages: [],
+      pendingRequests: new Set(),
+    };
+
+    this.streams.set(streamId, streamInfo);
+
+    if (session) {
+      session.streams.set(streamId, streamInfo);
+      session.lastActivity = Date.now();
+    }
+
+    return { stream, streamId };
+  }
+
+  /**
+   * Replay messages on a stream from a given event ID
+   */
+  private async replayMessages(
+    session: Session,
+    streamId: string,
+    lastEventId: string
+  ): Promise<void> {
+    // Find stream with matching last event ID
+    for (const oldStreamInfo of session.streams.values()) {
+      // Skip current stream
+      if (oldStreamInfo.id === streamId) continue;
+
+      // Find position in message history
+      const lastEventIndex = Number.parseInt(lastEventId, 10);
+      if (Number.isNaN(lastEventIndex)) continue;
+
+      // Replay messages after the last received event
+      const messagesToReplay = oldStreamInfo.messages.slice(lastEventIndex);
+      const newStreamInfo = this.streams.get(streamId);
+
+      if (newStreamInfo && messagesToReplay.length > 0) {
+        for (const message of messagesToReplay) {
+          await this.sendToStream(newStreamInfo, message);
+        }
+      }
+    }
+  }
+
+  /**
+   * Start periodic cleanup of expired sessions
+   */
+  private startSessionCleanup(): void {
+    setInterval(() => {
+      const now = Date.now();
+      for (const [sessionId, session] of this.sessions.entries()) {
+        if (now - session.lastActivity > this.options.timeout!) {
+          // Close all streams
+          for (const [streamId, streamInfo] of session.streams.entries()) {
+            try {
+              streamInfo.writer
+                .close()
+                .catch((e) => console.warn("Error closing stream:", e));
+            } catch (error) {
+              console.warn("Error closing stream:", error);
+            }
+            this.streams.delete(streamId);
+          }
+
+          // Remove the session
+          this.sessions.delete(sessionId);
+        }
+      }
+    }, 60000); // Check every minute
+  }
+
+  /**
+   * Extract JSON-RPC message(s) from HTTP request
+   */
+  private async extractJSONRPC(
+    request: Request
+  ): Promise<JSONRPCMessage | JSONRPCMessage[]> {
+    // TODO - Check request size to ensure it's not surpassing the configured size
+
+    // Parse request body as JSON
+    try {
+      // Clone the request to ensure we can read it
+      const clonedRequest = request.clone();
+      const text = await clonedRequest.text();
+
+      if (!text) {
+        throw new Error("Empty request body");
+      }
+
+      return JSON.parse(text);
+    } catch (error) {
+      throw new Error(`Failed to parse JSON-RPC message: ${error}`);
+    }
+  }
+
+  /**
+   * Validate origin header to prevent DNS rebinding attacks
+   */
+  private validateOrigin(request: Request): void {
+    const origin = request.headers.get("Origin");
+
+    // Simple check for demo purposes
+    // In production, you would implement a more robust validation
+    if (origin && !this.isValidOrigin(origin)) {
+      throw new Error("Invalid origin");
+    }
+  }
+
+  /**
+   * Check if an origin is valid
+   */
+  private isValidOrigin(origin: string): boolean {
+    // TODO - enable users to provide a whitelist of allowed origins
+    return true;
+  }
+
+  /**
+   * Check if a message is a JSON-RPC request
+   */
+  private isRequest(message: JSONRPCMessage): message is JSONRPCRequest {
+    return (
+      message !== null &&
+      typeof message === "object" &&
+      "jsonrpc" in message &&
+      message.jsonrpc === "2.0" &&
+      "method" in message &&
+      "id" in message &&
+      message.id !== null &&
+      message.id !== undefined
+    );
+  }
+
+  /**
+   * Generate a fallback UUID if crypto.randomUUID is not available
+   */
+  private generateFallbackUUID(): string {
+    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+      const r = (Math.random() * 16) | 0;
+      const v = c === "x" ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
+  }
+}

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -1,0 +1,63 @@
+import type { JSONRPCMessage } from "../jsonrpc2/types.js";
+
+/**
+ * MessageHandler is a JSON RPC handler for processing messages on the transport
+ *
+ * @param message - The received JSON-RPC message
+ * @returns - A promise that resolves to a response JSON RPC message or void (for notifications)
+ */
+export type MessageHandler = (
+  message: JSONRPCMessage
+) => Promise<JSONRPCMessage | undefined>;
+
+export interface TransportOptions {
+  timeout?: number;
+  headers?: Record<string, string>;
+  enableSessions?: boolean;
+  fetch?: typeof fetch;
+}
+
+/**
+ * Describes the minimal contract for a MCP transport that a client or server can communicate over.
+ */
+export interface Transport {
+  /**
+   * Connects and starts receiving messages.
+   */
+  connect(): Promise<void>;
+
+  /**
+   * Send a JSON RPC Message on the connected transport
+   */
+  send(message: JSONRPCMessage): Promise<void>;
+
+  /**
+   * Handler for received messages
+   */
+  onMessage(handler: MessageHandler): void;
+
+  /**
+   * Closes the connection.
+   */
+  close(): Promise<void>;
+
+  /**
+   * Sets a callback for when the transport is closed
+   */
+  onClose?: (callback: () => void) => void;
+
+  /**
+   * Sets a callback for transport errors
+   */
+  onError(callback: (error: Error) => void): void;
+
+  /**
+   * Get the current session ID if one exists
+   */
+  getSessionId(): string | undefined;
+
+  /**
+   * Set a session ID for subsequent requests
+   */
+  setSessionId(sessionId: string | undefined): void;
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "lib": ["ESNext", "WebWorker", "Webworker.Iterable"],
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "strict": true,
+    "target": "ES2022",
+    "baseUrl": ".",
+    "paths": {
+      "@zuplo/mcp/*": ["./src/*"]
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,16 @@
 {
-  "include": ["src/**/*", "types/**/*"],
-  "exclude": ["src/**/*.test.ts", "node_modules", "dist"],
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "node",
-    "esModuleInterop": true,
-    "declaration": true,
     "outDir": "./dist",
-    "rootDir": "./src",
-    "strict": true,
-    "lib": ["ESNext", "WebWorker", "Webworker.Iterable"],
-    "sourceMap": true
-  }
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+      "examples/**/*",
+      "src/**/*.test.ts",
+      "node_modules",
+      "dist"
+  ]
 }


### PR DESCRIPTION
This PR is a good touch point for a few things:

```
* Adhere to ES Module ".js" extensions throughout
* Adds a MCPServer class in src/server
* Adds examples in examples/
* Adds a stub httpstreamable transport in src/transport (WIP
```

The biggest things are 1) a working `MCPServer` class and 2) Correct tool calling off the server (see the runnable example in `examples/tools-server/src/index.ts`)