### PR TITLE
feat: `MCPServer` connected to `Transport`

### DIFF
--- a/examples/ping-server/src/index.ts
+++ b/examples/ping-server/src/index.ts
@@ -1,13 +1,56 @@
 import { JSONRPCRequest } from "@zuplo/mcp/jsonrpc2/types";
 import { MCPServer } from "@zuplo/mcp/server";
+import { HTTPStreamableTransport } from "@zuplo/mcp/transport/httpstreamable";
 
-// Create a simple server
+// Creates a simple MCP server
 const server = new MCPServer({
   name: "Example Ping Server",
   version: "1.0.0",
 });
 
 console.log("Server capabilities:", server.getCapabilities());
+
+// HTTP Streamable Transport for handling POST Requests
+const transport = new HTTPStreamableTransport()
+await transport.connect();
+
+server.withTransport(transport);
+
+// 1. Initialize the server
+const initRequest: JSONRPCRequest = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: {
+      name: "ExampleClient",
+      version: "1.0.0"
+    }
+  }
+}
+
+// Package ping JSONRPC2 into Request
+let httpRequest = new Request("http://example.com/mcp", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+  },
+  body: JSON.stringify(initRequest)
+});
+
+try {
+  const response = await transport.handleRequest(httpRequest);
+  const bodyText = await response.text();
+
+  console.log("HTTP Status:", response.status);
+  console.log("Response headers:", Object.fromEntries(response.headers.entries()));
+  console.log("Response body:", bodyText);
+} catch (e) {
+  console.log("Error", e);
+}
 
 // Example ping request
 const pingRequest: JSONRPCRequest = {
@@ -16,10 +59,25 @@ const pingRequest: JSONRPCRequest = {
   method: "ping",
 };
 
-async function runExample() {
-  console.log("Sending ping request:", pingRequest);
-  const response = await server.handleRequest(pingRequest);
-  console.log("Received response:", response);
-}
+// Package ping JSONRPC2 into Request
+httpRequest = new Request("http://example.com/mcp", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Accept": "application/json"
+  },
+  body: JSON.stringify(pingRequest)
+});
 
-runExample().catch(console.error);
+// Handle the request using the transport
+console.log("Sending HTTP request with ping payload");
+try {
+  const response = await transport.handleRequest(httpRequest);
+  const bodyText = await response.text();
+
+  console.log("HTTP Status:", response.status);
+  console.log("Response headers:", Object.fromEntries(response.headers.entries()));
+  console.log("Response body:", bodyText);
+} catch (e) {
+  console.log("Error", e);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "pkce-challenge": "^5.0.0",
         "zod": "^3.24.4",
         "zod-to-json-schema": "^3.24.5"
       },
@@ -3485,15 +3484,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/pkce-challenge": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
-      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
     "./server": {
       "types": "./dist/server/index.d.ts",
       "import": "./dist/server/index.js"
+    },
+    "./transport/httpstreamable": {
+      "types": "./dist/transport/httpstreamable.d.ts",
+      "import": "./dist/transport/httpstreamable.js"
     }
   },
   "repository": {

--- a/src/transport/httpstreamable.test.ts
+++ b/src/transport/httpstreamable.test.ts
@@ -1,0 +1,79 @@
+import { HTTPStreamableTransport } from "./httpstreamable.js";
+import { MCPServer } from "../server/index.js";
+import { jest } from "@jest/globals";
+
+describe("HTTPStreamableTransport Accept header validation", () => {
+  let server: MCPServer;
+  let transport: HTTPStreamableTransport;
+
+  beforeEach(() => {
+    server = new MCPServer({ name: "test", version: "0.0.0" });
+    transport = new HTTPStreamableTransport();
+    transport.connect();
+    server.withTransport(transport);
+
+    // Mock methods we're not testing
+    (transport as any).validateOrigin = jest.fn();
+  });
+
+  // Helper function to create requests with different Accept headers
+  const createRequestWithAccept = (acceptHeader?: string): Request => {
+    const headers: HeadersInit = {
+      "Content-Type": "application/json",
+    };
+
+    if (acceptHeader !== undefined) {
+      headers["Accept"] = acceptHeader;
+    }
+
+    return new Request("http://example.com/mcp", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "ping",
+      }),
+    });
+  };
+
+  it("rejects requests with no Accept header", async () => {
+    const request = createRequestWithAccept(undefined);
+    const response = await transport.handleRequest(request);
+
+    expect(response.status).toBe(406);
+
+    const responseBody = await response.json();
+    expect(responseBody.jsonrpc).toBe("2.0");
+    expect(responseBody.error.code).toBe(-32600);
+    expect(responseBody.error.message).toContain("Not Acceptable");
+    expect(responseBody.id).toBeNull();
+  });
+
+  it("rejects requests with empty Accept header", async () => {
+    const request = createRequestWithAccept("");
+    const response = await transport.handleRequest(request);
+
+    expect(response.status).toBe(406);
+    const responseBody = await response.json();
+    expect(responseBody.error.code).toBe(-32600);
+  });
+
+  it("rejects requests with incompatible Accept header", async () => {
+    const request = createRequestWithAccept("application/xml");
+    const response = await transport.handleRequest(request);
+
+    expect(response.status).toBe(406);
+    const responseBody = await response.json();
+    expect(responseBody.error.code).toBe(-32600);
+  });
+
+  it("accepts requests with application/json Accept header", async () => {
+    const request = createRequestWithAccept("application/json");
+    const response = await transport.handleRequest(request);
+
+    expect(response.status).toBe(200);
+    const responseBody = await response.json();
+    expect(responseBody.result.pong).toBe(true);
+  });
+});

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -8,7 +8,7 @@ import type { JSONRPCMessage } from "../jsonrpc2/types.js";
  */
 export type MessageHandler = (
   message: JSONRPCMessage
-) => Promise<JSONRPCMessage | undefined>;
+) => Promise<JSONRPCMessage | null>;
 
 export interface TransportOptions {
   timeout?: number;


### PR DESCRIPTION
This implements an MCP server connecting with a transport (where the `onMessage` handler is used by the MCP server. This can be accomplished through:

```ts
const transport = new HTTPStreamableTransport()
await transport.connect();

server.withTransport(transport);
```

`Request` can then be handled by the transport:

```ts
await transport.handleRequest(httpRequest);
```