### PR TITLE
feat: Ping and full initialization

### DIFF
--- a/examples/ping-server/README.md
+++ b/examples/ping-server/README.md
@@ -1,0 +1,37 @@
+# Simple ping server
+
+The following is a very simple "ping" MCP server.
+
+It has no tools, it has no
+capabilities: it primarily only responds to `method.ping` requests after the initialization flow
+[as defined in the MCP spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/utilities/ping).
+
+## 🏃 Build & run the server
+
+```
+npm i
+npm run build
+npm run start
+```
+
+## 🧠 Interact
+
+Use the [Model Context Protocol Inspector](https://github.com/modelcontextprotocol/inspector)
+and `localhost:3000/mcp`.
+
+```sh
+npx @modelcontextprotocol/inspector
+```
+
+or curl:
+
+```sh
+curl -X POST \
+  -H 'Accept: application/json' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "123",
+    "method": "ping"
+  }' \
+  localhost:3000/mcp
+```

--- a/examples/ping-server/package-lock.json
+++ b/examples/ping-server/package-lock.json
@@ -6,7 +6,9 @@
     "": {
       "name": "@zuplo/mcp ping example",
       "dependencies": {
-        "@zuplo/mcp": "file:../../"
+        "@hono/node-server": "^1.14.1",
+        "@zuplo/mcp": "file:../../",
+        "hono": "^4.7.9"
       }
     },
     "..": {
@@ -44,9 +46,30 @@
         "typescript": "^5.8.3"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.14.1.tgz",
+      "integrity": "sha512-vmbuM+HPinjWzPe7FFPWMMQMsbKE9gDPhaH0FFdqbGpkT5lp++tcWDTxwBl5EgS5y6JVgIaCdjeHRfQ4XRBRjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@zuplo/mcp": {
       "resolved": "../..",
       "link": true
+    },
+    "node_modules/hono": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.7.9.tgz",
+      "integrity": "sha512-/EsCoR5h7N4yu01TDu9GMCCJa6ZLk5ZJIWFFGNawAXmd1Tp53+Wir4xm0D2X19bbykWUlzQG0+BvPAji6p9E8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
     }
   }
 }

--- a/examples/ping-server/package.json
+++ b/examples/ping-server/package.json
@@ -7,6 +7,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@zuplo/mcp": "file:../../"
+    "@hono/node-server": "^1.14.1",
+    "@zuplo/mcp": "file:../../",
+    "hono": "^4.7.9"
   }
 }

--- a/examples/ping-server/src/index.ts
+++ b/examples/ping-server/src/index.ts
@@ -1,83 +1,38 @@
-import { JSONRPCRequest } from "@zuplo/mcp/jsonrpc2/types";
+import { serve } from '@hono/node-server'
+import { Hono } from 'hono';
 import { MCPServer } from "@zuplo/mcp/server";
 import { HTTPStreamableTransport } from "@zuplo/mcp/transport/httpstreamable";
 
-// Creates a simple MCP server
+// Hono app for routing and handling fetch API Request / Response
+const app = new Hono();
+
+// MCP server
 const server = new MCPServer({
   name: "Example Ping Server",
   version: "1.0.0",
 });
 
-console.log("Server capabilities:", server.getCapabilities());
-
-// HTTP Streamable Transport for handling POST Requests
-const transport = new HTTPStreamableTransport()
+// HTTP Streamable Transport
+const transport = new HTTPStreamableTransport();
 await transport.connect();
-
 server.withTransport(transport);
 
-// 1. Initialize the server
-const initRequest: JSONRPCRequest = {
-  jsonrpc: "2.0",
-  id: 1,
-  method: "initialize",
-  params: {
-    protocolVersion: "2024-11-05",
-    capabilities: {},
-    clientInfo: {
-      name: "ExampleClient",
-      version: "1.0.0"
-    }
+// Set up a POST route for MCP requests
+app.post('/mcp', async (c) => {
+  try {
+    const request = c.req.raw;
+    return transport.handleRequest(request);
+  } catch (error) {
+    console.error('Error handling MCP request:', error);
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
   }
-}
-
-// Package ping JSONRPC2 into Request
-let httpRequest = new Request("http://example.com/mcp", {
-  method: "POST",
-  headers: {
-    "Content-Type": "application/json",
-    "Accept": "application/json",
-  },
-  body: JSON.stringify(initRequest)
 });
 
-try {
-  const response = await transport.handleRequest(httpRequest);
-  const bodyText = await response.text();
-
-  console.log("HTTP Status:", response.status);
-  console.log("Response headers:", Object.fromEntries(response.headers.entries()));
-  console.log("Response body:", bodyText);
-} catch (e) {
-  console.log("Error", e);
-}
-
-// Example ping request
-const pingRequest: JSONRPCRequest = {
-  jsonrpc: "2.0",
-  id: 1,
-  method: "ping",
-};
-
-// Package ping JSONRPC2 into Request
-httpRequest = new Request("http://example.com/mcp", {
-  method: "POST",
-  headers: {
-    "Content-Type": "application/json",
-    "Accept": "application/json"
-  },
-  body: JSON.stringify(pingRequest)
+console.log("serving on port 3000")
+serve({
+  fetch: app.fetch,
+  port: 3000
 });
-
-// Handle the request using the transport
-console.log("Sending HTTP request with ping payload");
-try {
-  const response = await transport.handleRequest(httpRequest);
-  const bodyText = await response.text();
-
-  console.log("HTTP Status:", response.status);
-  console.log("Response headers:", Object.fromEntries(response.headers.entries()));
-  console.log("Response body:", bodyText);
-} catch (e) {
-  console.log("Error", e);
-}

--- a/src/server/initialization.test.ts
+++ b/src/server/initialization.test.ts
@@ -1,11 +1,11 @@
-import { MCPServer } from './index';
-import { JSONRPCRequest } from '../jsonrpc2/types';
-import { LATEST_PROTOCOL_VERSION } from '../mcp/versions';
-import { InitializeResult } from '../mcp/20250326/types/types';
+import { MCPServer } from "./index";
+import { JSONRPCRequest } from "../jsonrpc2/types";
+import { LATEST_PROTOCOL_VERSION } from "../mcp/versions";
+import { InitializeResult } from "../mcp/20250326/types/types";
 
-describe('MCPServer', () => {
-  describe('handleRequest', () => {
-    it('properly handles initialization request', async () => {
+describe("MCPServer", () => {
+  describe("initialize", () => {
+    it("properly handles initialization request", async () => {
       const serverName = "example ping server";
       const serverVersion = "0.0.0";
       const server = new MCPServer({
@@ -14,32 +14,31 @@ describe('MCPServer', () => {
       });
 
       const clientReq: JSONRPCRequest = {
-        jsonrpc: '2.0',
+        jsonrpc: "2.0",
         id: 0,
-        method: 'initialize',
+        method: "initialize",
         params: {
-          protocolVersion: '2025-03-26',
+          protocolVersion: "2025-03-26",
           capabilities: {
             sampling: {},
             roots: {
-              listChanged: true
-            }
+              listChanged: true,
+            },
           },
           clientInfo: {
-            name: 'mcp-client',
-            version: '0.0.0'
-          }
-        }
+            name: "mcp-client",
+            version: "0.0.0",
+          },
+        },
       };
 
       const response = await server.handleRequest(clientReq);
 
       expect(response).toBeDefined();
-      expect(response.jsonrpc).toBe('2.0');
+      expect(response.jsonrpc).toBe("2.0");
       expect(response.id).toBe(0);
 
-      // Check it's a response, not an error
-      if ('result' in response) {
+      if ("result" in response) {
         const result = response.result as InitializeResult;
 
         // Verify protocol version matches the latest
@@ -47,21 +46,19 @@ describe('MCPServer', () => {
 
         // Verify capabilities are correctly included
         expect(result.capabilities).toEqual({
-          ping: true,
           tools: {
             supported: true,
-            available: []
-          }
+            available: [],
+          },
         });
 
         // Verify server info is correctly included
         expect(result.serverInfo).toEqual({
           name: serverName,
-          version: serverVersion
+          version: serverVersion,
         });
       } else {
-        // If this executes, the test will fail because we expect a result, not an error
-        fail('Expected a result, got an error response');
+        fail("Expected a result, got an error response with no result");
       }
     });
   });

--- a/src/server/ping.test.ts
+++ b/src/server/ping.test.ts
@@ -1,0 +1,32 @@
+import { MCPServer } from "./index";
+import { JSONRPCRequest } from "../jsonrpc2/types";
+
+describe("MCPServer", () => {
+  describe("ping", () => {
+    it("properly handles ping request", async () => {
+      const server = new MCPServer({
+        name: "example ping server",
+        version: "0.0.0",
+      });
+
+      const pingRequest: JSONRPCRequest = {
+        jsonrpc: "2.0",
+        id: "123",
+        method: "ping",
+      };
+
+      const response = await server.handleRequest(pingRequest);
+
+      expect(response).toBeDefined();
+      expect(response.jsonrpc).toBe("2.0");
+      expect(response.id).toBe("123");
+
+      if ("result" in response) {
+        // resulting "pong" should be an empty object
+        expect(response.result).toEqual({});
+      } else {
+        fail("Expected a result response, got an error response");
+      }
+    });
+  });
+});

--- a/src/transport/httpstreamable.test.ts
+++ b/src/transport/httpstreamable.test.ts
@@ -74,6 +74,6 @@ describe("HTTPStreamableTransport Accept header validation", () => {
 
     expect(response.status).toBe(200);
     const responseBody = await response.json();
-    expect(responseBody.result.pong).toBe(true);
+    expect(responseBody.result).toEqual({});
   });
 });


### PR DESCRIPTION
* Full `method: ping` capabilities
  * Fixed `capabilities` to not include `ping` which is not actually defined as a capability in MCP
* Uses a `switch (request.method)` instead of cascading if blocks on the MCP `method` to be handled
* Fully fleshed out ping server example (with Hono server for `Request` and `Response`)
* `handleNotification` now simply logs the request (notifications not currently handled from clients)
* New method `handleToolListRequest` returns a list of tools
* Fixed tests where necessary (and added a ping specific test suite)
* Formatting fixes