### PR TITLE
feat: Adds custom validators and lifts/shifts Zod into its own validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ const server = new MCPServer({
 server.addTool({
   name: "add",
   description: "Adds two numbers together and returns the result.",
-  schema: z.object({ a: z.number(), b: z.number() }),
+  validator: new ZodValidator(
+    z.object({
+      a: z.number().describe("First number"),
+      b: z.number().describe("Second number")
+    })
+  ),
   handler: async ({ a, b }) => ({
     content: [{ type: "text", text: String(a + b) }],
     isError: false,

--- a/examples/ajv-tools/README.md
+++ b/examples/ajv-tools/README.md
@@ -1,7 +1,10 @@
-# Calculator server
+# Custom Ajv validator
 
-This calculator has a few mathematical tools (like addition, division, sqrt, modulo, etc.)
-and can be utilized by an MCP client to run calculations remotely.
+This demonstrates using Ajv with the `CustomValidator` to in an advanced use case to:
+
+1. Build a custom schema validator function based on a concrete type / schema using `ajv.compile`
+2. Build a hand rolled, "bring your own validator" with `CustomValidator<T>`
+3. Provide the custom validator when bootstrapping a tool
 
 ## 🏃 Build & run the server
 

--- a/examples/ajv-tools/package-lock.json
+++ b/examples/ajv-tools/package-lock.json
@@ -1,0 +1,129 @@
+{
+  "name": "@zuplo/mcp example tools server",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zuplo/mcp example tools server",
+      "dependencies": {
+        "@hono/node-server": "^1.14.1",
+        "@zuplo/mcp": "file:../../",
+        "ajv": "^8.17.1",
+        "hono": "^4.7.9"
+      }
+    },
+    "..": {
+      "name": "@zuplo/mcp",
+      "version": "0.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.24.4",
+        "zod-to-json-schema": "^3.24.5"
+      },
+      "devDependencies": {
+        "@types/jest": "^29.5.14",
+        "@types/node": "^22.15.14",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.3.2",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.3"
+      }
+    },
+    "../..": {
+      "name": "@zuplo/mcp",
+      "version": "0.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.24.4",
+        "zod-to-json-schema": "^3.24.5"
+      },
+      "devDependencies": {
+        "@types/jest": "^29.5.14",
+        "@types/node": "^22.15.14",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.3.2",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.14.1.tgz",
+      "integrity": "sha512-vmbuM+HPinjWzPe7FFPWMMQMsbKE9gDPhaH0FFdqbGpkT5lp++tcWDTxwBl5EgS5y6JVgIaCdjeHRfQ4XRBRjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@zuplo/mcp": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/hono": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.7.9.tgz",
+      "integrity": "sha512-/EsCoR5h7N4yu01TDu9GMCCJa6ZLk5ZJIWFFGNawAXmd1Tp53+Wir4xm0D2X19bbykWUlzQG0+BvPAji6p9E8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  }
+}

--- a/examples/ajv-tools/package.json
+++ b/examples/ajv-tools/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@zuplo/mcp example tools server",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.14.1",
+    "@zuplo/mcp": "file:../../",
+    "ajv": "^8.17.1",
+    "hono": "^4.7.9"
+  }
+}

--- a/examples/ajv-tools/src/index.ts
+++ b/examples/ajv-tools/src/index.ts
@@ -1,0 +1,77 @@
+import { serve } from '@hono/node-server'
+import { Hono } from 'hono';
+import { MCPServer } from "@zuplo/mcp/server";
+import { HTTPStreamableTransport } from "@zuplo/mcp/transport/httpstreamable";
+import Ajv, { JSONSchemaType } from 'ajv';
+import { CustomValidator } from '@zuplo/mcp/tools/custom';
+
+// Hono app for routing and handling fetch API Request / Response
+const app = new Hono();
+
+// MCP server
+const server = new MCPServer({
+  name: "Calculator",
+  version: "0.0.0",
+});
+
+const ajv = new Ajv();
+
+type NumberPair = { a: number; b: number };
+
+const numberPairSchema: JSONSchemaType<NumberPair> = {
+  type: "object",
+  properties: {
+    a: { type: "number" },
+    b: { type: "number" },
+  },
+  required: ["a", "b"],
+  additionalProperties: false,
+};
+
+const validateFn = ajv.compile<NumberPair>(numberPairSchema);
+
+const numberPairValidator = new CustomValidator<NumberPair>(
+  numberPairSchema,
+  (input) => {
+    if (validateFn(input)) {
+      return { success: true, data: input, error: null }
+    };
+
+    return { success: false, data: null, error: ajv.errorsText(validateFn.errors) }
+  }
+);
+
+server.addTool({
+  name: "add",
+  description: "Adds two numbers together",
+  validator: numberPairValidator,
+  handler: async ({ a, b }) => ({
+    content: [{ type: "text", text: String(a + b) }],
+    isError: false,
+  }),
+});
+
+// HTTP Streamable Transport
+const transport = new HTTPStreamableTransport();
+await transport.connect();
+server.withTransport(transport);
+
+// Set up a POST route for MCP requests
+app.post('/mcp', async (c) => {
+  try {
+    const request = c.req.raw;
+    return transport.handleRequest(request);
+  } catch (error) {
+    console.error('Error handling MCP request:', error);
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+});
+
+console.log("serving on port 3000")
+serve({
+  fetch: app.fetch,
+  port: 3000
+});

--- a/examples/ajv-tools/tsconfig.json
+++ b/examples/ajv-tools/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "./src/**/*"
+  ],
+  "references": [
+    { "path": "../../" }
+  ]
+}

--- a/examples/calculator/src/index.ts
+++ b/examples/calculator/src/index.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono';
 import { MCPServer } from "@zuplo/mcp/server";
 import { HTTPStreamableTransport } from "@zuplo/mcp/transport/httpstreamable";
 import { z } from 'zod';
+import { ZodValidator } from '@zuplo/mcp/tools/zod';
 
 // Hono app for routing and handling fetch API Request / Response
 const app = new Hono();
@@ -17,10 +18,12 @@ const server = new MCPServer({
 server.addTool({
   name: "add",
   description: "Adds two numbers together and returns the result.",
-  schema: z.object({
-    a: z.number().describe("First number"),
-    b: z.number().describe("Second number")
-  }),
+  validator: new ZodValidator(
+    z.object({
+      a: z.number().describe("First number"),
+      b: z.number().describe("Second number")
+    })
+  ),
   handler: async ({ a, b }) => ({
     content: [{ type: "text", text: String(a + b) }],
     isError: false,
@@ -31,10 +34,12 @@ server.addTool({
 server.addTool({
   name: "subtract",
   description: "Subtracts the second number from the first and returns the result.",
-  schema: z.object({
-    a: z.number().describe("Number to subtract from"),
-    b: z.number().describe("Number to subtract")
-  }),
+  validator: new ZodValidator(
+    z.object({
+      a: z.number().describe("Number to subtract from"),
+      b: z.number().describe("Number to subtract")
+    })
+  ),
   handler: async ({ a, b }) => ({
     content: [{ type: "text", text: String(a - b) }],
     isError: false,
@@ -45,10 +50,12 @@ server.addTool({
 server.addTool({
   name: "multiply",
   description: "Multiplies two numbers together and returns the result.",
-  schema: z.object({
-    a: z.number().describe("First number"),
-    b: z.number().describe("Second number")
-  }),
+  validator: new ZodValidator(
+    z.object({
+      a: z.number().describe("First number"),
+      b: z.number().describe("Second number")
+    })
+  ),
   handler: async ({ a, b }) => ({
     content: [{ type: "text", text: String(a * b) }],
     isError: false,
@@ -59,14 +66,16 @@ server.addTool({
 server.addTool({
   name: "divide",
   description: "Divides the first number by the second and returns the result.",
-  schema: z.object({
-    a: z.number().describe("Dividend (number to be divided)"),
-    b: z.number()
-      .refine(val => val !== 0, {
-        message: "Cannot divide by zero"
-      })
-      .describe("Divisor (number to divide by)")
-  }),
+  validator: new ZodValidator(
+    z.object({
+      a: z.number().describe("Dividend (number to be divided)"),
+      b: z.number()
+        .refine(val => val !== 0, {
+          message: "Cannot divide by zero"
+        })
+        .describe("Divisor (number to divide by)")
+    })
+  ),
   handler: async ({ a, b }) => {
     if (b === 0) {
       return {
@@ -85,10 +94,12 @@ server.addTool({
 server.addTool({
   name: "power",
   description: "Raises the first number to the power of the second number.",
-  schema: z.object({
-    base: z.number().describe("The base number"),
-    exponent: z.number().describe("The exponent")
-  }),
+  validator: new ZodValidator(
+    z.object({
+      base: z.number().describe("The base number"),
+      exponent: z.number().describe("The exponent")
+    })
+  ),
   handler: async ({ base, exponent }) => ({
     content: [{ type: "text", text: String(Math.pow(base, exponent)) }],
     isError: false,
@@ -99,11 +110,13 @@ server.addTool({
 server.addTool({
   name: "sqrt",
   description: "Calculates the square root of the given number.",
-  schema: z.object({
-    number: z.number()
-      .min(0, { message: "Cannot calculate square root of negative numbers" })
-      .describe("The number to calculate the square root of")
-  }),
+  validator: new ZodValidator(
+    z.object({
+      number: z.number()
+        .min(0, { message: "Cannot calculate square root of negative numbers" })
+        .describe("The number to calculate the square root of")
+    })
+  ),
   handler: async ({ number }) => {
     if (number < 0) {
       return {
@@ -122,14 +135,16 @@ server.addTool({
 server.addTool({
   name: "modulo",
   description: "Returns the remainder of dividing the first number by the second.",
-  schema: z.object({
-    a: z.number().describe("Dividend"),
-    b: z.number()
-      .refine(val => val !== 0, {
-        message: "Modulo by zero is not allowed"
-      })
-      .describe("Divisor")
-  }),
+  validator: new ZodValidator(
+    z.object({
+      a: z.number().describe("Dividend"),
+      b: z.number()
+        .refine(val => val !== 0, {
+          message: "Modulo by zero is not allowed"
+        })
+        .describe("Divisor")
+    })
+  ),
   handler: async ({ a, b }) => {
     if (b === 0) {
       return {
@@ -148,13 +163,15 @@ server.addTool({
 server.addTool({
   name: "factorial",
   description: "Calculates the factorial of the given integer.",
-  schema: z.object({
-    number: z.number()
-      .int()
-      .min(0, { message: "Factorial is only defined for non-negative integers" })
-      .max(170, { message: "Number too large, would cause overflow" })
-      .describe("The non-negative integer to calculate factorial for")
-  }),
+  validator: new ZodValidator(
+    z.object({
+      number: z.number()
+        .int()
+        .min(0, { message: "Factorial is only defined for non-negative integers" })
+        .max(170, { message: "Number too large, would cause overflow" })
+        .describe("The non-negative integer to calculate factorial for")
+    })
+  ),
   handler: async ({ number }) => {
     if (number < 0 || !Number.isInteger(number)) {
       return {

--- a/examples/zod-tools/README.md
+++ b/examples/zod-tools/README.md
@@ -1,7 +1,6 @@
-# Calculator server
+# Echo server with Zod validator
 
-This calculator has a few mathematical tools (like addition, division, sqrt, modulo, etc.)
-and can be utilized by an MCP client to run calculations remotely.
+This implements a simple echo tool using the `ZodValidator` for schema validation.
 
 ## 🏃 Build & run the server
 
@@ -28,10 +27,9 @@ curl -X POST \
   -d '{
     method: "tools/call"
     params:{
-      name: "add"
+      name: "echo"
       arguments:{
-        a: 1
-        b: 2
+        input: "hello"
       }
     }
   }' \

--- a/examples/zod-tools/package-lock.json
+++ b/examples/zod-tools/package-lock.json
@@ -1,0 +1,75 @@
+{
+  "name": "@zuplo/mcp example tools server",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zuplo/mcp example tools server",
+      "dependencies": {
+        "@hono/node-server": "^1.14.1",
+        "@zuplo/mcp": "file:../../"
+      }
+    },
+    "..": {
+      "name": "@zuplo/mcp",
+      "version": "0.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.24.4",
+        "zod-to-json-schema": "^3.24.5"
+      },
+      "devDependencies": {
+        "@types/jest": "^29.5.14",
+        "@types/node": "^22.15.14",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.3.2",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.3"
+      }
+    },
+    "../..": {
+      "name": "@zuplo/mcp",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.24.4",
+        "zod-to-json-schema": "^3.24.5"
+      },
+      "devDependencies": {
+        "@types/jest": "^29.5.14",
+        "@types/node": "^22.15.14",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.3.2",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.14.1.tgz",
+      "integrity": "sha512-vmbuM+HPinjWzPe7FFPWMMQMsbKE9gDPhaH0FFdqbGpkT5lp++tcWDTxwBl5EgS5y6JVgIaCdjeHRfQ4XRBRjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@zuplo/mcp": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/hono": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.7.9.tgz",
+      "integrity": "sha512-/EsCoR5h7N4yu01TDu9GMCCJa6ZLk5ZJIWFFGNawAXmd1Tp53+Wir4xm0D2X19bbykWUlzQG0+BvPAji6p9E8Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    }
+  }
+}

--- a/examples/zod-tools/package.json
+++ b/examples/zod-tools/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@zuplo/mcp example zod validator tool",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.14.1",
+    "@zuplo/mcp": "file:../../",
+    "hono": "^4.7.9"
+  }
+}

--- a/examples/zod-tools/src/index.ts
+++ b/examples/zod-tools/src/index.ts
@@ -1,0 +1,54 @@
+import { serve } from '@hono/node-server'
+import { Hono } from 'hono';
+import { MCPServer } from "@zuplo/mcp/server";
+import { HTTPStreamableTransport } from "@zuplo/mcp/transport/httpstreamable";
+import { z } from 'zod';
+import { ZodValidator } from '@zuplo/mcp/tools/zod';
+
+// Hono app for routing and handling fetch API Request / Response
+const app = new Hono();
+
+// MCP server
+const server = new MCPServer({
+  name: "Calculator",
+  version: "0.0.0",
+});
+
+server.addTool({
+  name: "echo",
+  description: "A simple echo tool that uses the Zod validator for schema checking",
+  validator: new ZodValidator(
+    z.object({
+      toEcho: z.string().describe("The input string to echo back")
+    })
+  ),
+  handler: async ({ toEcho }) => ({
+    content: [{ type: "text", text: toEcho }],
+    isError: false,
+  })
+});
+
+// HTTP Streamable Transport
+const transport = new HTTPStreamableTransport();
+await transport.connect();
+server.withTransport(transport);
+
+// Set up a POST route for MCP requests
+app.post('/mcp', async (c) => {
+  try {
+    const request = c.req.raw;
+    return transport.handleRequest(request);
+  } catch (error) {
+    console.error('Error handling MCP request:', error);
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+});
+
+console.log("serving on port 3000")
+serve({
+  fetch: app.fetch,
+  port: 3000
+});

--- a/examples/zod-tools/tsconfig.json
+++ b/examples/zod-tools/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "./src/**/*"
+  ],
+  "references": [
+    { "path": "../../" }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zuplo/mcp",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zuplo/mcp",
-      "version": "0.0.1",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.4",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,14 @@
     "./transport/httpstreamable": {
       "types": "./dist/transport/httpstreamable.d.ts",
       "import": "./dist/transport/httpstreamable.js"
+    },
+    "./tools/zod": {
+      "types": "./dist/tools/zod.d.ts",
+      "import": "./dist/tools/zod.js"
+    },
+    "./tools/custom": {
+      "types": "./dist/tools/custom.d.ts",
+      "import": "./dist/tools/custom.js"
     }
   },
   "repository": {

--- a/src/tools/custom.ts
+++ b/src/tools/custom.ts
@@ -1,0 +1,31 @@
+import type {
+  InputParamValidator,
+  InputParamValidatorReturn,
+} from "../server/types.js";
+
+/**
+ * CustomValidator is a hands-off, “bring-your-own-validator” which
+ * @implements {InputParamValidator} and is expected that the caller provide a custom
+ * "parse" function.
+ *
+ * @param T - the runtime type produced by the validator
+ * @param S - the raw JSON Schema object
+ *
+ * The caller provides a "parseFn" that returns a @type InputParamValidatorReturn
+ * which is used to infer the type of the JSON schema in a tool's handler
+ * callback.
+ *
+ * This implementation matches the contract of "InputValidator<T>.parse".
+ */
+export class CustomValidator<T, S extends object = object>
+  implements InputParamValidator<T>
+{
+  constructor(
+    public readonly jsonSchema: S,
+    private readonly parseFn: (input: unknown) => InputParamValidatorReturn<T>
+  ) {}
+
+  parse(input: unknown): InputParamValidatorReturn<T> {
+    return this.parseFn(input);
+  }
+}

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,0 +1,20 @@
+import type { CallToolResult } from "../mcp/20250326/types/types.js";
+import type { InputParamValidator, ParsedData } from "../server/types.js";
+
+/**
+ * ToolConfig is the configuration object provided to "addTool". It is used
+ * by callers to denote the name, description, validator, and handler of a tool.
+ *
+ * @param V - The input validator that is used to validate a tool call's params
+ * @param R - The expected results of a tool call
+ * defaults to @type CallToolResult
+ */
+export interface ToolConfig<
+  V extends InputParamValidator<unknown>,
+  R extends CallToolResult = CallToolResult,
+> {
+  name: string;
+  validator: V;
+  handler: (params: ParsedData<V>) => Promise<R> | R;
+  description?: string;
+}

--- a/src/tools/zod.ts
+++ b/src/tools/zod.ts
@@ -1,0 +1,33 @@
+import type { AnyZodObject, z } from "zod";
+import zodToJsonSchema from "zod-to-json-schema";
+import type {
+  InputParamValidator,
+  InputParamValidatorReturn,
+} from "../server/types.js";
+
+/**
+ * ZodValidator is a input JSON params validator class which uses Zod and
+ * @implements {InputParamValidator}
+ *
+ * @param S - the Zod schema object. This is used to "parse" and provide
+ * validated params to tool calls.
+ */
+
+export class ZodValidator<S extends AnyZodObject>
+  implements InputParamValidator<z.infer<S>>
+{
+  readonly jsonSchema: object;
+  readonly schema: S;
+
+  constructor(schema: S) {
+    this.jsonSchema = zodToJsonSchema(schema);
+    this.schema = schema;
+  }
+
+  parse(input: unknown): InputParamValidatorReturn<z.infer<S>> {
+    const parsed = this.schema.safeParse(input);
+    return parsed.success
+      ? { success: true, data: parsed.data, error: null }
+      : { success: false, data: null, error: parsed.error.message };
+  }
+}


### PR DESCRIPTION
Closes #15 

---

This implements custom "validators" that can be provided when tools are being added to an MCP server. There are 2 validators that implement `InputParamValidator`:

1) the Zod validator (the most turnkey solution for most people):

```ts
server.addTool({
  name: "echo",
  description: "A simple echo tool that uses the Zod validator for schema checking",
  validator: new ZodValidator(
    z.object({
      toEcho: z.string().describe("The input string to echo back")
    })
  ),
  handler: async ({ toEcho }) => ({
    content: [{ type: "text", text: toEcho }],
    isError: false,
  })
});
```

2) a "custom" validator that can be used with any bespoke validation function (like Ajv):

```ts
const ajv = new Ajv();

type NumberPair = { a: number; b: number };

const numberPairSchema: JSONSchemaType<NumberPair> = {
  type: "object",
  properties: {
    a: { type: "number" },
    b: { type: "number" },
  },
  required: ["a", "b"],
  additionalProperties: false,
};

const validateFn = ajv.compile<NumberPair>(numberPairSchema);

const numberPairValidator = new CustomValidator<NumberPair>(
  numberPairSchema,
  (input) => {
    if (validateFn(input)) {
      return { success: true, data: input, error: null }
    };

    return { success: false, data: null, error: ajv.errorsText(validateFn.errors) }
  }
);

server.addTool({
  name: "add",
  description: "Adds two numbers together",
  validator: numberPairValidator,
  handler: async ({ a, b }) => ({
    content: [{ type: "text", text: String(a + b) }],
    isError: false,
  }),
});
```

---

Instead of overloading `addTool` with different input params or mechanisms to check what schema validator was being used, I went with the approach to have a simple API contract with `InputParamValidator`:

```ts
export interface InputParamValidator<T> {
  jsonSchema: object;
  parse(input: unknown): InputParamValidatorReturn<T>;
}
```

It simply expects that a validator has the JSON schema as an object and some parse function (which takes an unknown input and returns the input param validation return object). This then can be utilized (and infer the `handler`'s input params for an excellent developer experience).