### PR TITLE
feat: OpenAPI extension support

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,10 @@
     "./tools/types": {
       "types": "./dist/tools/types.d.ts",
       "import": "./dist/tools/types.js"
+    },
+    "./openapi/types": {
+      "types": "./dist/openapi/types.d.ts",
+      "import": "./dist/openapi/types.js"
     }
   },
   "repository": {

--- a/src/openapi/types.ts
+++ b/src/openapi/types.ts
@@ -1,0 +1,64 @@
+/**
+ * OpenAPI MCP server metadata support via "x-mcp-server" extension.
+ *
+ * @example
+ * ```json
+ * {
+ *   "paths": {
+ *     "mcp": {
+ *       "post: {
+ *         "name": "my MCP server name",
+ *         "version": "1.2.3",
+ *         "tools": [
+ *           {
+ *             "name": "get_all_users",
+ *             "description": "Tool for getting all users in the system"
+ *           },
+ *           {
+ *             "name": "create_new_user",
+ *             "description": "Tool for creating a new user",
+ *             "inputSchema": { ... }
+ *           }
+ *         ]
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export interface ExtensionMcpServer {
+  /**
+   * The name of the MCP server itself: this is advertised during MCP initialization
+   */
+  name: string;
+
+  /**
+   * The version of the MCP server itself: this is advertised during MCP initialization
+   */
+  version: string;
+
+  /**
+   * Array of tool metadata in the server
+   */
+  tools: ExtensionMcpServerTool[];
+}
+
+/**
+ * Individual tool metadata for a "x-mcp-server" tool list
+ */
+export interface ExtensionMcpServerTool {
+  /**
+   * The name of the MCP tool
+   */
+  name: string;
+
+  /**
+   * The description of the MCP tool
+   */
+  description: string;
+
+  /**
+   * JSON Schema for the tool's input parameters
+   */
+  inputSchema?: object;
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -37,6 +37,9 @@ import type {
   RegisteredTool,
 } from "./types.js";
 
+export const DEFAULT_MCP_SERVER_NAME = "MCP Server";
+export const DEFAULT_MCP_SERVER_VERSION = "0.0.0";
+
 export class MCPServer {
   private capabilities: ServerCapabilities;
   private tools: Map<string, RegisteredTool> = new Map();
@@ -46,8 +49,8 @@ export class MCPServer {
   private logger: Logger;
 
   constructor(options: MCPServerOptions) {
-    this.name = options.name || "MCP Server";
-    this.version = options.version || "1.0.0";
+    this.name = options.name || DEFAULT_MCP_SERVER_NAME;
+    this.version = options.version || DEFAULT_MCP_SERVER_VERSION;
     this.instructions = options.instructions || undefined;
     this.logger = options.logger || createDefaultLogger();
 


### PR DESCRIPTION
* Support for a `x-mcp-server` metadata and tool metadata interfaces.
* Exported default server name and version