### PR TITLE
fix: Makes OpenAPI server extension tools optional

### DIFF
--- a/src/openapi/types.ts
+++ b/src/openapi/types.ts
@@ -38,9 +38,9 @@ export interface ExtensionMcpServer {
   version: string;
 
   /**
-   * Array of tool metadata in the server
+   * Optional: array of tool metadata in the server
    */
-  tools: ExtensionMcpServerTool[];
+  tools?: ExtensionMcpServerTool[];
 }
 
 /**


### PR DESCRIPTION
Makes the tools array in the `x-mcp-server` OpenAPI extension optional