### PR TITLE
Fix sse and respect mcp session

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -17,9 +17,10 @@ class MockTransport implements Transport {
   private messageHandler?: (
     message: JSONRPCMessage
   ) => Promise<JSONRPCMessage | null>;
-  private responses: Map<number, unknown> = new Map();
 
   async connect(): Promise<void> {}
+
+  setHeaders(_headers: Record<string, string>): void {}
 
   async send(message: JSONRPCMessage): Promise<void> {
     // Simulate response based on method
@@ -28,6 +29,10 @@ class MockTransport implements Transport {
       let response: JSONRPCResponse;
 
       switch (message.method) {
+        case "notifications/initialized":
+          // This is a notification, no response expected
+          return;
+
         case "initialize":
           response = newJSONRPCReponse({
             id,
@@ -130,13 +135,13 @@ class MockTransport implements Transport {
 
   async close(): Promise<void> {}
 
-  onError(callback: (error: Error) => void): void {}
+  onError(_callback: (error: Error) => void): void {}
 
   getSessionId(): string | undefined {
     return undefined;
   }
 
-  setSessionId(sessionId: string | undefined): void {}
+  setSessionId(_sessionId: string | undefined): void {}
 }
 
 describe("MCPClient", () => {

--- a/src/transport/httpclient.ts
+++ b/src/transport/httpclient.ts
@@ -94,7 +94,7 @@ export class HTTPClientTransport implements Transport {
       // (https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management)
       const responseSessionId = response.headers.get("Mcp-Session-Id");
       if (responseSessionId && !this.sessionId) {
-        this.sessionId = responseSessionId;
+        this.setSessionId(responseSessionId);
       }
 
       // Check content type to determine response format


### PR DESCRIPTION
  Fix multiple issues preventing the MCP client from working correctly with                              
  SSE-based servers like Atlassian MCP.                                                                  
                                                                                                         
  The previous implementation replaced the message handler on every request,                             
  causing responses to be lost when multiple requests were in flight. This                               
  was fixed by using a stable message handler with a pending requests map                                
  to correlate responses with their originating requests.                                                
                                                                                                         
  Additionally:                                                                                          
  - Capture and forward Mcp-Session-Id header from server responses, which                               
    is required by servers for subsequent requests per MCP spec                                          
  - Pass abort signal to SSE stream handling for proper timeout behavior                                 
  - Handle notifications as fire-and-forget (don't await response)                                       
  - Send notifications/initialized after initialize per MCP lifecycle spec 