### PR TITLE
test: add schema-level tests to lock down current zod behavior

### DIFF
--- a/src/jsonrpc2/schemas/error.test.ts
+++ b/src/jsonrpc2/schemas/error.test.ts
@@ -1,0 +1,61 @@
+import { JSONRPCErrorSchema } from "./error.js";
+
+describe("JSONRPCErrorSchema", () => {
+  const valid = {
+    jsonrpc: "2.0" as const,
+    id: 1,
+    error: {
+      code: -32600,
+      message: "Invalid Request",
+    },
+  };
+
+  it("accepts a minimal valid error", () => {
+    const result = JSONRPCErrorSchema.safeParse(valid);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an error with optional data", () => {
+    const result = JSONRPCErrorSchema.safeParse({
+      ...valid,
+      error: { ...valid.error, data: { foo: "bar" } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a null id (parse-error case)", () => {
+    const result = JSONRPCErrorSchema.safeParse({ ...valid, id: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a string id", () => {
+    const result = JSONRPCErrorSchema.safeParse({ ...valid, id: "req-1" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects extra top-level properties (strict)", () => {
+    const result = JSONRPCErrorSchema.safeParse({ ...valid, extra: "no" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-integer error.code", () => {
+    const result = JSONRPCErrorSchema.safeParse({
+      ...valid,
+      error: { ...valid.error, code: 1.5 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects wrong jsonrpc version literal", () => {
+    const result = JSONRPCErrorSchema.safeParse({ ...valid, jsonrpc: "1.0" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing error.message", () => {
+    const result = JSONRPCErrorSchema.safeParse({
+      ...valid,
+      error: { code: -32600 },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/jsonrpc2/schemas/notifications.test.ts
+++ b/src/jsonrpc2/schemas/notifications.test.ts
@@ -1,0 +1,63 @@
+import {
+  BaseNotificationParamsSchema,
+  JSONRPCNotificationSchema,
+  NotificationSchema,
+} from "./notifications.js";
+
+describe("BaseNotificationParamsSchema (loose)", () => {
+  it("accepts an empty object", () => {
+    const r = BaseNotificationParamsSchema.safeParse({});
+    expect(r.success).toBe(true);
+  });
+
+  it("preserves unknown properties (loose)", () => {
+    const r = BaseNotificationParamsSchema.safeParse({ extra: 1 });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts a _meta object with arbitrary content", () => {
+    const r = BaseNotificationParamsSchema.safeParse({
+      _meta: { custom: "ok" },
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe("NotificationSchema", () => {
+  it("accepts method only", () => {
+    const r = NotificationSchema.safeParse({ method: "x" });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts method and params", () => {
+    const r = NotificationSchema.safeParse({
+      method: "x",
+      params: { foo: "bar" },
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe("JSONRPCNotificationSchema (strict)", () => {
+  const valid = { jsonrpc: "2.0" as const, method: "notifications/foo" };
+
+  it("accepts a minimal notification", () => {
+    const r = JSONRPCNotificationSchema.safeParse(valid);
+    expect(r.success).toBe(true);
+  });
+
+  it("does NOT include id (notifications)", () => {
+    const r = JSONRPCNotificationSchema.safeParse({ ...valid, id: 1 });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects extra top-level fields (strict)", () => {
+    const r = JSONRPCNotificationSchema.safeParse({ ...valid, extra: 1 });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects wrong jsonrpc literal", () => {
+    const r = JSONRPCNotificationSchema.safeParse({ ...valid, jsonrpc: "1.0" });
+    expect(r.success).toBe(false);
+  });
+});

--- a/src/jsonrpc2/schemas/request.test.ts
+++ b/src/jsonrpc2/schemas/request.test.ts
@@ -1,0 +1,87 @@
+import {
+  BaseRequestParamsSchema,
+  JSONRPCRequestSchema,
+  RequestMetaSchema,
+} from "./request.js";
+
+describe("RequestMetaSchema (loose)", () => {
+  it("accepts an empty object", () => {
+    const r = RequestMetaSchema.safeParse({});
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts a string progressToken", () => {
+    const r = RequestMetaSchema.safeParse({ progressToken: "abc" });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts an integer progressToken", () => {
+    const r = RequestMetaSchema.safeParse({ progressToken: 42 });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects a non-integer progressToken number", () => {
+    const r = RequestMetaSchema.safeParse({ progressToken: 1.5 });
+    expect(r.success).toBe(false);
+  });
+
+  it("preserves unknown properties (loose mode)", () => {
+    const r = RequestMetaSchema.safeParse({
+      progressToken: "tok",
+      custom: "value",
+      another: 123,
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      const data = r.data as Record<string, unknown>;
+      expect(data.custom).toBe("value");
+      expect(data.another).toBe(123);
+    }
+  });
+});
+
+describe("BaseRequestParamsSchema (loose)", () => {
+  it("accepts empty params", () => {
+    const r = BaseRequestParamsSchema.safeParse({});
+    expect(r.success).toBe(true);
+  });
+
+  it("preserves unknown properties (loose mode)", () => {
+    const r = BaseRequestParamsSchema.safeParse({ extra: "kept" });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect((r.data as Record<string, unknown>).extra).toBe("kept");
+    }
+  });
+
+  it("validates _meta when present", () => {
+    const r = BaseRequestParamsSchema.safeParse({
+      _meta: { progressToken: "x" },
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe("JSONRPCRequestSchema (strict)", () => {
+  const valid = { jsonrpc: "2.0" as const, id: 1, method: "ping" };
+
+  it("accepts a minimal valid request", () => {
+    const r = JSONRPCRequestSchema.safeParse(valid);
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts a request with params", () => {
+    const r = JSONRPCRequestSchema.safeParse({ ...valid, params: {} });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects extra top-level properties (strict)", () => {
+    const r = JSONRPCRequestSchema.safeParse({ ...valid, extra: "nope" });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects missing method", () => {
+    const r = JSONRPCRequestSchema.safeParse({ jsonrpc: "2.0", id: 1 });
+    expect(r.success).toBe(false);
+  });
+});

--- a/src/jsonrpc2/schemas/response.test.ts
+++ b/src/jsonrpc2/schemas/response.test.ts
@@ -1,0 +1,71 @@
+import {
+  EmptyResultSchema,
+  JSONRPCResponseSchema,
+  ResultSchema,
+} from "./response.js";
+
+describe("ResultSchema (loose)", () => {
+  it("accepts an empty object", () => {
+    const r = ResultSchema.safeParse({});
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts arbitrary extra fields (loose mode)", () => {
+    const r = ResultSchema.safeParse({ foo: "bar", n: 1 });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      const data = r.data as Record<string, unknown>;
+      expect(data.foo).toBe("bar");
+      expect(data.n).toBe(1);
+    }
+  });
+
+  it("accepts a _meta object with arbitrary fields (loose)", () => {
+    const r = ResultSchema.safeParse({ _meta: { customMeta: "ok" } });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe("EmptyResultSchema (strict)", () => {
+  it("accepts a fully empty result", () => {
+    const r = EmptyResultSchema.safeParse({});
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts a result with only _meta", () => {
+    const r = EmptyResultSchema.safeParse({ _meta: {} });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects extra top-level fields (strict)", () => {
+    const r = EmptyResultSchema.safeParse({ extra: "nope" });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("JSONRPCResponseSchema (strict)", () => {
+  const valid = { jsonrpc: "2.0" as const, id: 1, result: {} };
+
+  it("accepts a minimal valid response", () => {
+    const r = JSONRPCResponseSchema.safeParse(valid);
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects extra top-level fields (strict)", () => {
+    const r = JSONRPCResponseSchema.safeParse({ ...valid, extra: 1 });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects missing result", () => {
+    const r = JSONRPCResponseSchema.safeParse({ jsonrpc: "2.0", id: 1 });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts arbitrary fields inside result (loose ResultSchema)", () => {
+    const r = JSONRPCResponseSchema.safeParse({
+      ...valid,
+      result: { extra: 1 },
+    });
+    expect(r.success).toBe(true);
+  });
+});

--- a/src/mcp/20250326/schemas/autocomplete.schema.test.ts
+++ b/src/mcp/20250326/schemas/autocomplete.schema.test.ts
@@ -1,0 +1,43 @@
+import { CompleteResultSchema } from "./autocomplete.schema.js";
+
+describe("CompleteResultSchema completion.values maxLength (100)", () => {
+  it("accepts an empty values array", () => {
+    const r = CompleteResultSchema.safeParse({
+      completion: { values: [] },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts exactly 100 values", () => {
+    const values = Array.from({ length: 100 }, (_, i) => `v${i}`);
+    const r = CompleteResultSchema.safeParse({ completion: { values } });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects 101 values", () => {
+    const values = Array.from({ length: 101 }, (_, i) => `v${i}`);
+    const r = CompleteResultSchema.safeParse({ completion: { values } });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts an integer total", () => {
+    const r = CompleteResultSchema.safeParse({
+      completion: { values: ["a"], total: 42 },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects a non-integer total", () => {
+    const r = CompleteResultSchema.safeParse({
+      completion: { values: ["a"], total: 1.5 },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts an optional hasMore boolean", () => {
+    const r = CompleteResultSchema.safeParse({
+      completion: { values: ["a"], hasMore: true },
+    });
+    expect(r.success).toBe(true);
+  });
+});

--- a/src/mcp/20250326/schemas/roots.schema.test.ts
+++ b/src/mcp/20250326/schemas/roots.schema.test.ts
@@ -1,0 +1,37 @@
+import { RootSchema } from "./roots.schema.js";
+
+describe("RootSchema (uri startsWith file://)", () => {
+  it("accepts a valid file URI", () => {
+    const r = RootSchema.safeParse({ uri: "file:///home/user/project" });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts a file URI with an optional name", () => {
+    const r = RootSchema.safeParse({
+      uri: "file:///workspace",
+      name: "my-workspace",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects a non-file URI", () => {
+    const r = RootSchema.safeParse({ uri: "https://example.com/path" });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects a string that does not start with file://", () => {
+    const r = RootSchema.safeParse({ uri: "/home/user/project" });
+    expect(r.success).toBe(false);
+  });
+
+  it("preserves extra properties (loose)", () => {
+    const r = RootSchema.safeParse({
+      uri: "file:///x",
+      custom: "kept",
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect((r.data as Record<string, unknown>).custom).toBe("kept");
+    }
+  });
+});

--- a/src/mcp/20250326/schemas/sampling.schema.test.ts
+++ b/src/mcp/20250326/schemas/sampling.schema.test.ts
@@ -1,0 +1,113 @@
+import {
+  CreateMessageRequestSchema,
+  CreateMessageResultSchema,
+  ModelPreferencesSchema,
+} from "./sampling.schema.js";
+
+describe("ModelPreferencesSchema priority bounds (0..1)", () => {
+  it("accepts 0 at the lower bound", () => {
+    const r = ModelPreferencesSchema.safeParse({ costPriority: 0 });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts 1 at the upper bound", () => {
+    const r = ModelPreferencesSchema.safeParse({ costPriority: 1 });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts a value in the middle of the range", () => {
+    const r = ModelPreferencesSchema.safeParse({ costPriority: 0.5 });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects a negative value", () => {
+    const r = ModelPreferencesSchema.safeParse({ costPriority: -0.01 });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects a value greater than 1", () => {
+    const r = ModelPreferencesSchema.safeParse({ costPriority: 1.01 });
+    expect(r.success).toBe(false);
+  });
+
+  it("applies the same bounds to speedPriority and intelligencePriority", () => {
+    expect(ModelPreferencesSchema.safeParse({ speedPriority: 2 }).success).toBe(
+      false
+    );
+    expect(
+      ModelPreferencesSchema.safeParse({ intelligencePriority: -1 }).success
+    ).toBe(false);
+    expect(
+      ModelPreferencesSchema.safeParse({
+        costPriority: 0.1,
+        speedPriority: 0.5,
+        intelligencePriority: 0.9,
+      }).success
+    ).toBe(true);
+  });
+});
+
+describe("CreateMessageRequestSchema (maxTokens int)", () => {
+  const validParams = {
+    method: "sampling/createMessage" as const,
+    params: {
+      messages: [
+        {
+          role: "user" as const,
+          content: { type: "text" as const, text: "Hi" },
+        },
+      ],
+      maxTokens: 100,
+    },
+  };
+
+  it("accepts an integer maxTokens", () => {
+    const r = CreateMessageRequestSchema.safeParse(validParams);
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects a non-integer maxTokens", () => {
+    const r = CreateMessageRequestSchema.safeParse({
+      ...validParams,
+      params: { ...validParams.params, maxTokens: 1.5 },
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("CreateMessageResultSchema stopReason (.or fallback)", () => {
+  const minimal = {
+    model: "gpt-4",
+    role: "assistant" as const,
+    content: { type: "text" as const, text: "ok" },
+  };
+
+  it("accepts the standard 'endTurn' value", () => {
+    const r = CreateMessageResultSchema.safeParse({
+      ...minimal,
+      stopReason: "endTurn",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts a non-standard string via the .or(z.string()) fallback", () => {
+    const r = CreateMessageResultSchema.safeParse({
+      ...minimal,
+      stopReason: "modelSpecificReason",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects a non-string stopReason", () => {
+    const r = CreateMessageResultSchema.safeParse({
+      ...minimal,
+      stopReason: 123,
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts a missing stopReason (optional)", () => {
+    const r = CreateMessageResultSchema.safeParse(minimal);
+    expect(r.success).toBe(true);
+  });
+});

--- a/src/mcp/20250326/schemas/tools.schema.test.ts
+++ b/src/mcp/20250326/schemas/tools.schema.test.ts
@@ -1,0 +1,159 @@
+import {
+  CallToolRequestSchema,
+  CallToolResultSchema,
+  CompatibilityCallToolResultSchema,
+  ToolSchema,
+} from "./tools.schema.js";
+
+describe("ToolSchema (loose)", () => {
+  const minimal = {
+    name: "echo",
+    inputSchema: { type: "object" as const },
+  };
+
+  it("accepts a minimal tool definition", () => {
+    const r = ToolSchema.safeParse(minimal);
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts a tool with description and annotations", () => {
+    const r = ToolSchema.safeParse({
+      ...minimal,
+      description: "An echo tool",
+      annotations: {
+        title: "Echo",
+        readOnlyHint: true,
+      },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("preserves extra top-level fields (loose)", () => {
+    const r = ToolSchema.safeParse({ ...minimal, custom: "kept" });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect((r.data as Record<string, unknown>).custom).toBe("kept");
+    }
+  });
+
+  it("preserves extra fields inside inputSchema (loose)", () => {
+    const r = ToolSchema.safeParse({
+      ...minimal,
+      inputSchema: {
+        type: "object",
+        required: ["x"],
+        additionalProperties: false,
+      },
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      const is = r.data.inputSchema as Record<string, unknown>;
+      expect(is.required).toEqual(["x"]);
+      expect(is.additionalProperties).toBe(false);
+    }
+  });
+
+  it("rejects inputSchema with type other than 'object'", () => {
+    const r = ToolSchema.safeParse({
+      ...minimal,
+      inputSchema: { type: "array" },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects missing name", () => {
+    const r = ToolSchema.safeParse({ inputSchema: { type: "object" } });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("CallToolResultSchema isError default", () => {
+  const minimal = {
+    content: [{ type: "text" as const, text: "hi" }],
+  };
+
+  // The schema is `z.boolean().default(false).optional()` (chainable
+  // form) — wrapping a default in optional means the default does NOT
+  // kick in when the field is missing; the value is left as undefined.
+  // Locking that behavior in here so the upgrade branch has to match.
+  it("leaves isError undefined when the field is missing", () => {
+    const r = CallToolResultSchema.safeParse(minimal);
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.isError).toBeUndefined();
+    }
+  });
+
+  it("accepts a result with isError: true", () => {
+    const r = CallToolResultSchema.safeParse({ ...minimal, isError: true });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.isError).toBe(true);
+    }
+  });
+
+  it("accepts a result with isError: false", () => {
+    const r = CallToolResultSchema.safeParse({ ...minimal, isError: false });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.isError).toBe(false);
+    }
+  });
+
+  it("rejects non-boolean isError", () => {
+    const r = CallToolResultSchema.safeParse({ ...minimal, isError: "yes" });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("CompatibilityCallToolResultSchema (.or fallback)", () => {
+  it("accepts a CallToolResult shape", () => {
+    const r = CompatibilityCallToolResultSchema.safeParse({
+      content: [{ type: "text", text: "ok" }],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts a legacy toolResult shape", () => {
+    const r = CompatibilityCallToolResultSchema.safeParse({
+      toolResult: { anything: "goes" },
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe("CallToolRequestSchema (extends RequestSchema)", () => {
+  const valid = {
+    method: "tools/call" as const,
+    params: { name: "echo", arguments: { msg: "hi" } },
+  };
+
+  it("accepts a valid call", () => {
+    const r = CallToolRequestSchema.safeParse(valid);
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects wrong method literal", () => {
+    const r = CallToolRequestSchema.safeParse({
+      ...valid,
+      method: "tools/list",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects missing params.name", () => {
+    const r = CallToolRequestSchema.safeParse({
+      method: "tools/call",
+      params: { arguments: {} },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts a call without arguments", () => {
+    const r = CallToolRequestSchema.safeParse({
+      method: "tools/call",
+      params: { name: "ping" },
+    });
+    expect(r.success).toBe(true);
+  });
+});

--- a/src/mcp/20251125/schemas/tools.schema.test.ts
+++ b/src/mcp/20251125/schemas/tools.schema.test.ts
@@ -1,0 +1,78 @@
+import { ToolSchema } from "./tools.schema.js";
+
+// The 20251125 ToolSchema is built via:
+//   BaseMetadataSchema.merge(IconsSchema).extend({ ... })
+// which exercises the .merge() pattern that gets rewritten on the
+// upgrade branch.
+
+describe("ToolSchema (20251125, merge + extend)", () => {
+  const minimal = {
+    name: "echo",
+    inputSchema: { type: "object" as const },
+  };
+
+  it("accepts the BaseMetadataSchema fields (name, title)", () => {
+    const r = ToolSchema.safeParse({ ...minimal, title: "Echo" });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.name).toBe("echo");
+      expect(r.data.title).toBe("Echo");
+    }
+  });
+
+  it("accepts the IconsSchema 'icons' field merged in", () => {
+    const r = ToolSchema.safeParse({
+      ...minimal,
+      icons: [{ src: "data:image/png;base64,abcd" }],
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.icons?.[0].src).toBe("data:image/png;base64,abcd");
+    }
+  });
+
+  it("accepts ToolSchema-extended fields (description, execution)", () => {
+    const r = ToolSchema.safeParse({
+      ...minimal,
+      description: "An echo tool",
+      execution: { taskSupport: "optional" },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("preserves arbitrary extra top-level fields (loose mode survives merge+extend)", () => {
+    const r = ToolSchema.safeParse({ ...minimal, custom: "kept" });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect((r.data as Record<string, unknown>).custom).toBe("kept");
+    }
+  });
+
+  it("accepts an outputSchema with $schema, type, properties, required", () => {
+    const r = ToolSchema.safeParse({
+      ...minimal,
+      outputSchema: {
+        $schema: "https://json-schema.org/draft/2020-12/schema",
+        type: "object",
+        properties: { x: {} },
+        required: ["x"],
+      },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects missing name (required from BaseMetadataSchema)", () => {
+    const r = ToolSchema.safeParse({
+      inputSchema: { type: "object" },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects taskSupport outside the allowed enum", () => {
+    const r = ToolSchema.safeParse({
+      ...minimal,
+      execution: { taskSupport: "always" },
+    });
+    expect(r.success).toBe(false);
+  });
+});

--- a/src/tools/zod.test.ts
+++ b/src/tools/zod.test.ts
@@ -1,0 +1,118 @@
+import { z } from "zod/v4";
+import { ZodValidator } from "./zod.js";
+
+describe("ZodValidator", () => {
+  describe("happy path", () => {
+    it("parses a valid object", () => {
+      const v = new ZodValidator(z.object({ name: z.string() }));
+      const r = v.parse({ name: "Alice" });
+      expect(r.success).toBe(true);
+      expect(r.data).toEqual({ name: "Alice" });
+      expect(r.errorData).toBeNull();
+    });
+
+    it("parses a valid empty object", () => {
+      const v = new ZodValidator(z.object({}));
+      const r = v.parse({});
+      expect(r.success).toBe(true);
+      expect(r.errorData).toBeNull();
+    });
+
+    it("parses nested objects with optional fields", () => {
+      const v = new ZodValidator(
+        z.object({
+          required: z.string(),
+          optional: z.optional(z.number()),
+          nested: z.object({ x: z.string() }),
+        })
+      );
+      const r = v.parse({ required: "ok", nested: { x: "y" } });
+      expect(r.success).toBe(true);
+    });
+
+    it("parses with arrays and unions", () => {
+      const v = new ZodValidator(
+        z.object({
+          values: z.array(z.union([z.string(), z.number()])),
+        })
+      );
+      const r = v.parse({ values: ["a", 1, "b", 2] });
+      expect(r.success).toBe(true);
+    });
+  });
+
+  describe("error path", () => {
+    it("returns success=false for the wrong type", () => {
+      const v = new ZodValidator(z.object({ name: z.string() }));
+      const r = v.parse({ name: 123 });
+      expect(r.success).toBe(false);
+      expect(r.data).toBeNull();
+      expect(r.errorData).not.toBeNull();
+    });
+
+    it("returns a non-empty errorMessage on failure", () => {
+      const v = new ZodValidator(z.object({ name: z.string() }));
+      const r = v.parse({ name: 123 });
+      expect(r.success).toBe(false);
+      expect(typeof r.errorMessage).toBe("string");
+      expect(r.errorMessage?.length ?? 0).toBeGreaterThan(0);
+    });
+
+    it("returns success=false for completely wrong shape", () => {
+      const v = new ZodValidator(z.object({ name: z.string() }));
+      const r = v.parse("not an object");
+      expect(r.success).toBe(false);
+      expect(r.data).toBeNull();
+    });
+
+    it("returns success=false for null input", () => {
+      const v = new ZodValidator(z.object({ name: z.string() }));
+      const r = v.parse(null);
+      expect(r.success).toBe(false);
+    });
+
+    it("reports missing required fields", () => {
+      const v = new ZodValidator(z.object({ name: z.string() }));
+      const r = v.parse({});
+      expect(r.success).toBe(false);
+      expect(r.errorData).not.toBeNull();
+    });
+  });
+
+  describe("jsonSchema generation", () => {
+    it("generates a JSON Schema with type 'object'", () => {
+      const v = new ZodValidator(z.object({ name: z.string() }));
+      expect(v.jsonSchema).toMatchObject({ type: "object" });
+    });
+
+    it("includes properties in the JSON Schema", () => {
+      const v = new ZodValidator(
+        z.object({ name: z.string(), age: z.number() })
+      );
+      const js = v.jsonSchema as {
+        type: string;
+        properties: Record<string, { type: string }>;
+      };
+      expect(js.properties.name.type).toBe("string");
+      expect(js.properties.age.type).toBe("number");
+    });
+
+    it("marks required fields", () => {
+      const v = new ZodValidator(
+        z.object({
+          required: z.string(),
+          opt: z.optional(z.string()),
+        })
+      );
+      const js = v.jsonSchema as { required?: string[] };
+      expect(js.required).toContain("required");
+      expect(js.required).not.toContain("opt");
+    });
+
+    it("preserves the schema reference on the instance", () => {
+      const schema = z.object({ name: z.string() });
+      const v = new ZodValidator(schema);
+      expect(v.schema).toBe(schema);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add direct \`safeParse\` tests for the schema patterns most likely to drift if the zod implementation changes — concretely, ahead of the zod 4 / \`zod/mini\` migration in #64. All tests run against the **current** zod 3 chainable schemas on \`main\` and capture the observable behavior we want to preserve.

98 new tests across 10 files, 167 total passing.

## Why now

PR #64 rewrites ~50 schema files from chainable to functional API. Several conversions look semantically equivalent but aren't trivially so — defaults wrapped in optional, \`.merge()\` → \`z.extend(a, b.shape)\` mode inheritance, range constraints (\`.min().max()\` → \`.check(z.gte(), z.lte())\`), and \`.or()\` → \`z.union\`. The existing test suite is mostly integration-level and doesn't directly exercise these edges.

By landing this PR first, #64 can rebase and we'll see immediately if any rewrite changed observable behavior.

## What's covered

| Area | What's locked down |
|---|---|
| \`ZodValidator\` ([src/tools/zod.ts](src/tools/zod.ts)) | Happy/error parse paths, \`jsonSchema\` generation, required-field markers, schema-reference identity |
| jsonrpc2 strict modes | \`JSONRPCErrorSchema\`, \`JSONRPCRequestSchema\`, \`JSONRPCResponseSchema\`, \`JSONRPCNotificationSchema\` reject extra top-level fields |
| jsonrpc2 loose modes | \`RequestMetaSchema\`, \`BaseRequestParamsSchema\`, \`BaseNotificationParamsSchema\`, \`ResultSchema\` preserve unknown fields |
| 20250326 \`ToolSchema\` | Loose mode survives, \`inputSchema.type\` literal check, missing-name rejection |
| 20250326 \`CallToolResultSchema\` | **\`isError\` is undefined when missing** — \`z.boolean().default(false).optional()\` does NOT apply the default. Locking this in. |
| 20250326 \`CompatibilityCallToolResultSchema\` | \`.or()\` fallback to legacy \`toolResult\` shape |
| 20250326 \`CallToolRequestSchema\` | Method literal, required \`params.name\` |
| 20250326 sampling | \`ModelPreferences\` priority bounds (0..1 inclusive), \`maxTokens\` int constraint, \`stopReason\` enum-or-string fallback |
| 20250326 \`RootSchema\` | \`uri\` \`startsWith("file://")\` constraint |
| 20250326 \`CompleteResultSchema\` | \`completion.values\` \`.max(100)\` upper bound, \`total\` int constraint |
| 20251125 \`ToolSchema\` | \`BaseMetadataSchema.merge(IconsSchema).extend(...)\` — merged \`name\`/\`title\`/\`icons\` fields all parse, loose mode survives |

## Notable finding

While writing these tests I confirmed that \`isError: z.boolean().default(false).optional()\` in \`CallToolResultSchema\` does **not** apply the default — the field is \`undefined\` when missing, not \`false\`. That's the existing behavior, so the tests lock it in. (If we want the default to actually apply we'd need a separate fix; this PR only documents current behavior.)

## Test plan

- [x] \`npx tsc\` clean
- [x] \`npm test\` — 167/167 passing
- [x] \`npm run lint\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)