### PR TITLE
ci: split release into tag creator + tag-triggered release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,24 +1,17 @@
-name: Cut Release
+name: Release
 on:
-  workflow_dispatch:
-    inputs:
-      bump:
-        description: "Part of the semantic version number to increment (major | minor | patch)"
-        type: choice
-        default: minor
-        required: true
-        options: [major, minor, patch]
+  push:
+    tags:
+      - "v*"
 
 jobs:
   release:
-    name: Build, tag & create a new release
+    name: Build, test & create GitHub release
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     permissions:
       contents: write
-      packages: write
-      id-token: write
 
     steps:
       - name: Generate token
@@ -38,63 +31,15 @@ jobs:
           node-version: 22.x
           cache: npm
 
-      # Run install, test, and builds for sanity check.
       - run: npm ci
       - run: npm test
       - run: npm run build
 
-      - name: Get latest tag
-        id: latest_tag
-        run: echo "tag=$(git describe --abbrev=0 --tags 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
-
-      - name: Bump semver tag
-        id: bump_tag
-        env:
-          LATEST_TAG: ${{ steps.latest_tag.outputs.tag }}
-          BUMP: ${{ inputs.bump }}
-        run: |
-          set -e
-          base=${LATEST_TAG#v}
-          if [[ -z "$base" ]]; then
-            echo "No tag found. Exiting."
-            exit 1
-          fi
-          IFS=. read -r maj min pat <<< "$base"
-          case "$BUMP" in
-            major) ((maj++)); min=0; pat=0 ;;
-            minor) ((min++)); pat=0 ;;
-            patch) ((pat++)) ;;
-          esac
-          next="$maj.$min.$pat"
-          echo "next_version=$next" >> "$GITHUB_OUTPUT"
-          echo "next_tag=v$next" >> "$GITHUB_OUTPUT"
-
-      # Updates package.json (but with no tag yet as it's not been committed)
-      - run: npm version ${{ steps.bump_tag.outputs.next_version }} --no-git-tag-version
-
-      # 6. Commit + tag
-      - name: Commit & tag
-        run: |
-          git config --local user.name  "github-actions[bot]"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json
-          git add package-lock.json
-          git commit -m "chore: bump version to ${{ steps.bump_tag.outputs.next_tag }}" || echo "nothing to commit"
-          git tag ${{ steps.bump_tag.outputs.next_tag }}
-
-      - run: |
-          git push origin HEAD:${GITHUB_REF#refs/heads/}
-          git push origin ${{ steps.bump_tag.outputs.next_tag }}
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
       - name: Create GitHub release
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ steps.bump_tag.outputs.next_tag }}
+          tag: ${{ github.ref_name }}
           generateReleaseNotes: true
-          # Because workflows cannot be triggered from other workflows using the
-          # default "GITHUB_TOKEN", we need the elevated token from the installed
-          # GitHub App. See more:
-          # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+          # Use the GitHub App token (not GITHUB_TOKEN) so the release event
+          # can trigger downstream workflows (e.g. publish.yaml).
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/run-release.yaml
+++ b/.github/workflows/run-release.yaml
@@ -1,0 +1,84 @@
+name: Run Release
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Part of the semantic version number to increment (major | minor | patch)"
+        type: choice
+        default: minor
+        required: true
+        options: [major, minor, patch]
+
+jobs:
+  tag:
+    name: Bump version & push tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.INTEGRATIONS_APP_ID }}
+          private-key: ${{ secrets.INTEGRATIONS_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Get latest tag
+        id: latest_tag
+        run: echo "tag=$(git describe --abbrev=0 --tags 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
+
+      - name: Bump semver tag
+        id: bump_tag
+        env:
+          LATEST_TAG: ${{ steps.latest_tag.outputs.tag }}
+          BUMP: ${{ inputs.bump }}
+        run: |
+          set -e
+          base=${LATEST_TAG#v}
+          if [[ -z "$base" ]]; then
+            echo "No tag found. Exiting."
+            exit 1
+          fi
+          IFS=. read -r maj min pat <<< "$base"
+          case "$BUMP" in
+            major) maj=$((maj + 1)); min=0; pat=0 ;;
+            minor) min=$((min + 1)); pat=0 ;;
+            patch) pat=$((pat + 1)) ;;
+          esac
+          next="$maj.$min.$pat"
+          echo "next_version=$next" >> "$GITHUB_OUTPUT"
+          echo "next_tag=v$next" >> "$GITHUB_OUTPUT"
+
+      # Update package.json (no git tag — we tag manually below).
+      - run: npm version ${{ steps.bump_tag.outputs.next_version }} --no-git-tag-version
+
+      - name: Commit & tag
+        run: |
+          git config --local user.name  "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          git add package-lock.json
+          git commit -m "chore: bump version to ${{ steps.bump_tag.outputs.next_tag }}" || echo "nothing to commit"
+          git tag ${{ steps.bump_tag.outputs.next_tag }}
+
+      # Pushing the tag triggers the Release workflow, which builds, tests,
+      # and creates the GitHub Release. Tags pushed locally trigger the same
+      # workflow, so this job is just a convenience wrapper around the bump.
+      - run: |
+          git push origin HEAD:${GITHUB_REF#refs/heads/}
+          git push origin ${{ steps.bump_tag.outputs.next_tag }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Splits the previous single 'Cut Release' workflow into two pieces so that you can either trigger a release from the GitHub UI **or** create the tag locally and push it.

| File | Name | Trigger | What it does |
|---|---|---|---|
| \`.github/workflows/run-release.yaml\` (renamed from \`release.yaml\`) | **Run Release** | \`workflow_dispatch\` (major / minor / patch) | Bumps \`package.json\`, commits, tags, pushes the tag. That's it. |
| \`.github/workflows/release.yaml\` (new) | **Release** | \`push\` of any \`v*\` tag | \`npm ci / test / build\`, then creates the GitHub Release. |
| \`.github/workflows/publish.yaml\` (unchanged) | Publish to Registries | \`release: published\` | Publishes to npm + GitHub Packages. |

So the flow is: **Run Release** (or \`git tag\` + \`git push\` locally) → **Release** runs on the tag → GitHub Release is created → **Publish** fires.

## Bug fix while I was here

The original bump script had \`((min++))\` / \`((pat++))\` under \`set -e\`, which exits with code 1 when the variable being post-incremented is \`0\` (the post-increment returns the pre-increment value, which arithmetic context treats as falsy). That's why the v0.0.32 → v0.1.0 minor bump just failed in [run 25524165303](https://github.com/zuplo/mcp/actions/runs/25524165303/job/74915612560). Replaced with \`min=\$((min + 1))\` style which doesn't have the trap.

## Why use a GitHub App token

\`Release\` keeps using the elevated app token when calling \`ncipollo/release-action\` because the default \`GITHUB_TOKEN\` can't trigger downstream workflows — without the app token, \`publish.yaml\` would never fire.

## Test plan

- [x] YAML validates (\`yaml.safe_load\`)
- [ ] Manual smoke test: trigger \`Run Release\` after merge, verify \`Release\` runs on the resulting tag, verify \`Publish\` runs on the resulting GitHub Release.
- [ ] Manual smoke test: locally \`git tag v0.x.0 && git push origin v0.x.0\`, verify \`Release\` runs and creates the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)