### PR TITLE
ci: pin npm to 11.5.1 in publish workflow to fix release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,10 @@ jobs:
           cache: npm
           registry-url: https://registry.npmjs.org
 
-      - run: npm install -g npm@latest
+      # Pin npm and use --force to avoid the self-upgrade race that leaves
+      # a half-installed module tree (Cannot find module 'promise-retry').
+      # We need npm 11.5+ for OIDC trusted publishers; 11.5.x is known good.
+      - run: npm install -g --force npm@11.5.1
       - run: npm ci
       - run: npm run build
 


### PR DESCRIPTION
## Summary

Two related fixes to unblock releases:

### 1. Pin npm in publish workflow

Fixes the v0.1.0 publish failure ([run 25524462714](https://github.com/zuplo/mcp/actions/runs/25524462714/job/74916597075)).

The \`npm install -g npm@latest\` step intermittently fails with:

\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
\`\`\`

This happens when npm tries to upgrade itself in-place and a previous file from the bundled npm gets deleted before the new version's modules are fully installed.

**Fix:** Pin to \`npm@11.5.1\` (the version that introduced OIDC trusted-publisher support — the reason this step exists at all) and pass \`--force\` so npm overwrites the existing installation cleanly.

### 2. Bump all GitHub Actions to latest major versions

| Action | Before | After |
|---|---|---|
| \`actions/checkout\` | v4 / v5 | v6 |
| \`actions/setup-node\` | v4 / v5 | v6 |
| \`actions/create-github-app-token\` | v1 | v3 |
| \`ncipollo/release-action\` | v1 | v1 (no change) |

Breaking-change review:
- \`setup-node\` v6 drops automatic non-npm caching — we only use npm caching, no impact.
- \`create-github-app-token\` v3 bumps to Node 24 + changes proxy handling — we don't use proxies; GitHub-hosted runners meet the v2.327.1+ requirement.
- \`checkout\` v6 changes credential persistence to a separate file — transparent for our use.

## Test plan

- [ ] Re-trigger the publish for v0.1.0 (or cut a fresh tag and watch the publish run end-to-end).
- [ ] Confirm CI runs cleanly on this PR (validates the action bumps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)