### PR TITLE
ci: bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,8 +10,8 @@ jobs:
     name: Lint, build, test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: "npm"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,11 +18,11 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: npm

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,17 +16,17 @@ jobs:
     steps:
       - name: Generate token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.INTEGRATIONS_APP_ID }}
           private-key: ${{ secrets.INTEGRATIONS_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: npm

--- a/.github/workflows/run-release.yaml
+++ b/.github/workflows/run-release.yaml
@@ -21,17 +21,17 @@ jobs:
     steps:
       - name: Generate token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.INTEGRATIONS_APP_ID }}
           private-key: ${{ secrets.INTEGRATIONS_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: npm


### PR DESCRIPTION
## Summary

Brings every action used across our four workflows to its latest major version.

| Action | Before | After |
|---|---|---|
| \`actions/checkout\` | v4 (ci, release, run-release) / v5 (publish) | v6 |
| \`actions/setup-node\` | v4 (ci, release, run-release) / v5 (publish) | v6 |
| \`actions/create-github-app-token\` | v1 (release, run-release) | v3 |
| \`ncipollo/release-action\` | v1 (release) | v1 (no change) |

## Breaking-change review

- **\`setup-node\` v6** drops automatic caching for non-npm package managers. We only use \`cache: npm\` everywhere, so no impact.
- **\`create-github-app-token\` v3** bumps the action's Node runtime to 24 and changes proxy handling (now requires \`NODE_USE_ENV_PROXY=1\` if you use \`HTTP_PROXY\`). We don't use proxies; GitHub-hosted runners already meet the v2.327.1+ requirement.
- **\`checkout\` v6** persists git credentials to a separate file. Transparent for our usage.

## Test plan

- [x] YAML validates (\`yaml.safe_load\`)
- [ ] CI on this PR exercises \`checkout@v6\` + \`setup-node@v6\` against our actual build/test/lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)