### PR TITLE
ci: make Run Release idempotent on package.json version

### DIFF
--- a/.github/workflows/run-release.yaml
+++ b/.github/workflows/run-release.yaml
@@ -63,7 +63,18 @@ jobs:
           echo "next_tag=v$next" >> "$GITHUB_OUTPUT"
 
       # Update package.json (no git tag — we tag manually below).
-      - run: npm version ${{ steps.bump_tag.outputs.next_version }} --no-git-tag-version
+      # Skip if package.json already matches (e.g. re-running after a
+      # prior failed run that already committed the bump).
+      - name: Bump package.json
+        env:
+          NEXT_VERSION: ${{ steps.bump_tag.outputs.next_version }}
+        run: |
+          current=$(node -p "require('./package.json').version")
+          if [ "$current" = "$NEXT_VERSION" ]; then
+            echo "package.json already at $NEXT_VERSION, skipping bump"
+          else
+            npm version "$NEXT_VERSION" --no-git-tag-version
+          fi
 
       - name: Commit & tag
         run: |


### PR DESCRIPTION
## Summary

Fixes the Run Release failure at [run 25525131470](https://github.com/zuplo/mcp/actions/runs/25525131470/job/74918795996):

\`\`\`
npm error Version not changed
\`\`\`

This happens when the previous Run Release attempt already committed the \`package.json\` version bump but the run later failed (and the user re-triggered). \`npm version X\` errors out when X is the current version.

## Fix

Read the current version with \`node -p\`, compare to the target, and only run \`npm version\` if they differ. The commit step that follows already tolerates a no-op (\`git commit … || echo "nothing to commit"\`), so the rest of the workflow handles the skip cleanly and proceeds to tag + push.

## Concretely for the v0.1.0 release

\`package.json\` on \`main\` is already at \`0.1.0\` (committed by [adfcd2b](https://github.com/zuplo/mcp/commit/adfcd2b)). Once this PR merges, re-trigger Run Release with \`minor\` and it'll skip the bump, tag the current main as \`v0.1.0\`, and push.

(Alternatively, since the version is already right, you can just \`git tag v0.1.0 && git push origin v0.1.0\` directly — the Release workflow will fire either way.)

## Test plan

- [x] YAML validates
- [ ] Run Release re-runs cleanly when \`package.json\` already matches the target version

🤖 Generated with [Claude Code](https://claude.com/claude-code)