### PR TITLE
ci: harden release workflows for re-runs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,6 +3,13 @@ on:
   release:
     types: [published]
 
+# One in-flight publish per release. If a release gets re-published
+# (e.g. delete + recreate), serialize to avoid concurrent npm publishes
+# stomping on each other.
+concurrency:
+  group: publish-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
 permissions:
   id-token: write # Required for OIDC - https://docs.npmjs.com/trusted-publishers
   contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,12 @@ on:
     tags:
       - "v*"
 
+# One in-flight release per tag. If the same tag is somehow pushed twice
+# (e.g. delete + recreate), serialize so they don't race.
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Build, test & create GitHub release
@@ -40,6 +46,10 @@ jobs:
         with:
           tag: ${{ github.ref_name }}
           generateReleaseNotes: true
+          # Update an existing release rather than failing — lets the
+          # workflow be re-run for a tag that already has a release
+          # (e.g. after fixing a publish failure).
+          allowUpdates: true
           # Use the GitHub App token (not GITHUB_TOKEN) so the release event
           # can trigger downstream workflows (e.g. publish.yaml).
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/run-release.yaml
+++ b/.github/workflows/run-release.yaml
@@ -62,8 +62,30 @@ jobs:
           echo "next_version=$next" >> "$GITHUB_OUTPUT"
           echo "next_tag=v$next" >> "$GITHUB_OUTPUT"
 
+      # Fail early with a clear message if the target tag already exists
+      # remotely. Re-using a tag would silently overwrite an existing release.
+      - name: Verify tag does not already exist
+        env:
+          NEXT_TAG: ${{ steps.bump_tag.outputs.next_tag }}
+        run: |
+          if git ls-remote --exit-code --tags origin "$NEXT_TAG" > /dev/null 2>&1; then
+            echo "::error::Tag $NEXT_TAG already exists on origin. Delete it first if you intend to re-release."
+            exit 1
+          fi
+
       # Update package.json (no git tag — we tag manually below).
-      - run: npm version ${{ steps.bump_tag.outputs.next_version }} --no-git-tag-version
+      # Skip if it already matches (e.g. a prior failed run committed
+      # the bump but didn't push the tag).
+      - name: Bump package.json
+        env:
+          NEXT_VERSION: ${{ steps.bump_tag.outputs.next_version }}
+        run: |
+          current=$(node -p "require('./package.json').version")
+          if [ "$current" = "$NEXT_VERSION" ]; then
+            echo "package.json already at $NEXT_VERSION, skipping bump"
+          else
+            npm version "$NEXT_VERSION" --no-git-tag-version
+          fi
 
       - name: Commit & tag
         run: |

--- a/.github/workflows/run-release.yaml
+++ b/.github/workflows/run-release.yaml
@@ -63,10 +63,10 @@ jobs:
           echo "next_tag=v$next" >> "$GITHUB_OUTPUT"
 
       # Fail early with a clear message if the target tag already exists
-      # remotely. Without this check the workflow would still bump
-      # package.json and create a no-op commit, then die at the final
-      # `git push origin <tag>` with a confusing 'rejected: already exists'
-      # error. Catching it up front avoids the dirty intermediate state.
+      # remotely. Without this check the workflow would bump package.json,
+      # commit, push the commit to main, and then die at `git push origin
+      # <tag>` with a confusing 'rejected: already exists' error — leaving
+      # main with a version-bump commit that has no corresponding tag.
       - name: Verify tag does not already exist
         env:
           NEXT_TAG: ${{ steps.bump_tag.outputs.next_tag }}

--- a/.github/workflows/run-release.yaml
+++ b/.github/workflows/run-release.yaml
@@ -63,7 +63,10 @@ jobs:
           echo "next_tag=v$next" >> "$GITHUB_OUTPUT"
 
       # Fail early with a clear message if the target tag already exists
-      # remotely. Re-using a tag would silently overwrite an existing release.
+      # remotely. Without this check the workflow would still bump
+      # package.json and create a no-op commit, then die at the final
+      # `git push origin <tag>` with a confusing 'rejected: already exists'
+      # error. Catching it up front avoids the dirty intermediate state.
       - name: Verify tag does not already exist
         env:
           NEXT_TAG: ${{ steps.bump_tag.outputs.next_tag }}


### PR DESCRIPTION
## Summary

Audited all four workflows for the failure modes hit during the v0.1.0 release attempts. Three hardening fixes; \`ci.yaml\` was already fine.

### \`run-release.yaml\`

1. **Skip the version bump if \`package.json\` already matches.** The previous failed v0.1.0 run committed the bump but didn't push the tag; re-running then died at \`npm version 0.1.0\` with "Version not changed". (This is the same fix as #69 — supersedes it.)
2. **Verify the target tag doesn't already exist on origin** before starting. Fails with a clear error message instead of silently overwriting an existing release.

### \`release.yaml\`

1. **\`allowUpdates: true\`** on \`ncipollo/release-action\`. If the workflow is re-triggered for a tag that already has a GitHub release (e.g. you fix a publish failure and re-run), the action updates the existing release instead of erroring out.
2. **Concurrency group** keyed on the tag (\`release-\${{ github.ref_name }}\`). Two pushes of the same tag (delete + recreate) will serialize instead of racing.

### \`publish.yaml\`

1. **Concurrency group** keyed on the release tag (\`publish-\${{ github.event.release.tag_name }}\`). Two publishes of the same release won't race for npm/GitHub Packages.

### \`ci.yaml\`

No changes — it's a simple lint/build/test on push and PR with no state to corrupt on re-run.

## Test plan

- [x] YAML validates
- [ ] Once merged, cut v0.1.0 (either via Run Release or by manually tagging) and watch the full chain: \`Release\` → GitHub release → \`Publish to Registries\` → npm + GitHub Packages.

## Note

Supersedes #69 (smaller-scope subset of these changes). Close #69 in favor of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)