### PR TITLE
chore: deprecate @zuplo/mcp in favor of @modelcontextprotocol/sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,18 @@
     <code>@zuplo/mcp</code>
   </p>
 </h1>
-  <p align="center">
-    A <code>fetch</code> API based, remote server first, TypeScript SDK for MCP.
-    <br />
-    <a href="#about">About</a>
-    ·
-    <a href="#documentation">Documentation</a>
-    ·
-    <a href="#contributing">Contributing</a>
-  </p>
-</p>
+
+> [!WARNING]
+> **This package is deprecated and is no longer maintained.**
+>
+> Please use the official Model Context Protocol TypeScript SDK instead: [`@modelcontextprotocol/sdk`](https://www.npmjs.com/package/@modelcontextprotocol/sdk) ([GitHub](https://github.com/modelcontextprotocol/typescript-sdk)).
 
 ---
 
-`@zuplo/mcp` is a stateless, remote server first MCP SDK that aims to be ["minimum common API" compliant as defined by the WinterTC](https://min-common-api.proposal.wintertc.org/).
-It uses the [`fetch` APIs](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) and is intended to work out of the box on Zuplo, Node, Deno, Workerd, etc.
+`@zuplo/mcp` was a stateless, remote server first MCP SDK that aimed to be ["minimum common API" compliant as defined by the WinterTC](https://min-common-api.proposal.wintertc.org/).
+It used the [`fetch` APIs](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) and was intended to work out of the box on Zuplo, Node, Deno, Workerd, etc.
+
+The official [`@modelcontextprotocol/sdk`](https://github.com/modelcontextprotocol/typescript-sdk) now covers these use cases and is the recommended path forward. New projects should adopt it directly, and existing users of `@zuplo/mcp` should migrate.
 
 # 📝 Documentation
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@zuplo/mcp",
   "version": "0.1.0",
   "description": "DEPRECATED — please use the official @modelcontextprotocol/sdk instead.",
-  "deprecated": "@zuplo/mcp is deprecated and no longer maintained. Please migrate to the official MCP TypeScript SDK: @modelcontextprotocol/sdk (https://github.com/modelcontextprotocol/typescript-sdk).",
   "type": "module",
   "scripts": {
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@zuplo/mcp",
   "version": "0.1.0",
-  "description": "A fetch API based, remote server first, TypeScript SDK for MCP.",
+  "description": "DEPRECATED — please use the official @modelcontextprotocol/sdk instead.",
+  "deprecated": "@zuplo/mcp is deprecated and no longer maintained. Please migrate to the official MCP TypeScript SDK: @modelcontextprotocol/sdk (https://github.com/modelcontextprotocol/typescript-sdk).",
   "type": "module",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary

Marks `@zuplo/mcp` as deprecated and points users to the official MCP TypeScript SDK, [`@modelcontextprotocol/sdk`](https://github.com/modelcontextprotocol/typescript-sdk).

## Changes

- **README.md** — adds a prominent `> [!WARNING]` deprecation callout at the top with a link to the official SDK, and rewords the description to past tense.
- **package.json** — updates `description` and adds a `deprecated` field with the migration message.

## Why

The official `@modelcontextprotocol/sdk` now covers the use cases this package was built for. New projects should adopt it directly, and existing users should migrate.

## Follow-up (manual)

To make `npm install @zuplo/mcp` actually surface a warning, the package must also be deprecated on the npm registry:

```sh
npm deprecate @zuplo/mcp "@zuplo/mcp is deprecated and no longer maintained. Please migrate to the official MCP TypeScript SDK: @modelcontextprotocol/sdk (https://github.com/modelcontextprotocol/typescript-sdk)."
```

This can only be done by a publisher with credentials to the npm package — it can't happen in CI from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)